### PR TITLE
Update student profile UI for phase 1

### DIFF
--- a/src/app/admin/students/profile/[studentId]/page.tsx
+++ b/src/app/admin/students/profile/[studentId]/page.tsx
@@ -2,7 +2,12 @@
 
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import { getStudentById, type StudentDetails, StudentProfileSkeleton } from "@/modules/students";
+import {
+  getStudentById,
+  type StudentDetails,
+  StudentProfileDocuments,
+  StudentProfileSkeleton,
+} from "@/modules/students";
 import Image from "next/image";
 import { Card } from "@/components/ui";
 import { CalendarCheck } from "lucide-react";
@@ -122,7 +127,7 @@ export default function StudentDetailsPage() {
                   Blood Group
                 </p>
                 <p className="text-[11px] lg:text-[14px] font-[500] text-gray-900">
-                  {student ? "-" : "-"}
+                  {student?.bloodGroup ?? "-"}
                 </p>
               </div>
 
@@ -142,7 +147,7 @@ export default function StudentDetailsPage() {
                   Aadhaar Number
                 </p>
                 <p className="text-[11px] lg:text-[14px] font-[500] text-gray-900">
-                  {student?.aadhaar ?? "-"}
+                  {student?.aadhaarNumber ?? student?.aadhaar ?? "-"}
                 </p>
               </div>
 
@@ -213,20 +218,38 @@ export default function StudentDetailsPage() {
 
               <div className="border border-blue-200 rounded-lg p-3 bg-blue-50">
                 <p className="text-xs lg:text-sm text-gray-500 mb-1">
-                  Parent Mail
+                  Mother Contact
                 </p>
                 <p className="text-[11px] lg:text-[14px] font-[500] text-gray-900">
-                  {student?.fatherEmail ?? "-"}
+                  {student?.motherMobile ?? "-"}
+                </p>
+              </div>
+
+              <div className="border border-blue-200 rounded-lg p-3 bg-blue-50">
+                <p className="text-xs lg:text-sm text-gray-500 mb-1">
+                  Guardian Name
+                </p>
+                <p className="text-[11px] lg:text-[14px] font-[500] text-gray-900">
+                  {student?.guardianName ?? "-"}
+                </p>
+              </div>
+
+              <div className="border border-blue-200 rounded-lg p-3 bg-blue-50">
+                <p className="text-xs lg:text-sm text-gray-500 mb-1">
+                  Guardian Contact
+                </p>
+                <p className="text-[11px] lg:text-[14px] font-[500] text-gray-900">
+                  {student?.guardianMobile ?? "-"}
                 </p>
               </div>
             </div>
             {/* Address (Full Width) */}
             <div className="c border border-blue-200 rounded-lg p-3 bg-blue-50 mt-4">
               <p className="text-xs lg:text-sm text-gray-500 mb-1">
-                Local Address
+                Medical Notes
               </p>
               <p className="text-[11px] lg:text-[14px] font-[500] text-gray-900">
-                {student?.emergencyContact ?? student?.address ?? "-"}
+                {student?.medicalNotes ?? "-"}
               </p>
             </div>
           </div>
@@ -344,97 +367,9 @@ export default function StudentDetailsPage() {
         </section>
       </div>
 
-      <div className="w-full max-w-full bg-white rounded-xl border border-blue-200 p-[20px]">
-        {/* Title */}
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">
-          Uploaded Documents
-        </h2>
-
-        {/* Document Item */}
-        <div className=" grid grid-cols-1 md:grid-cols-2 gap-4">
-          {/* Aadhaar Card */}
-          <div className="flex items-center justify-between border border-blue-200 rounded-lg p-4 bg-gray-50">
-            <div className="flex items-center gap-4">
-              <div className="w-10 h-10 flex items-center justify-center rounded-lg bg-white border border-blue-200">
-                📄
-              </div>
-              <div>
-                <p className="text-sm font-medium text-gray-900">Aadhar Card</p>
-                <span className="inline-block mt-1 px-2 py-[2px] text-xs font-medium text-blue-600 border border-blue-300 rounded-full">
-                  PDF
-                </span>
-              </div>
-            </div>
-            <div className="flex items-center gap-2 text-gray-500 text-sm cursor-pointer hover:text-blue-600">
-              👁
-              <span>View</span>
-            </div>
-          </div>
-
-          {/* Previous Marksheet */}
-          <div className="flex items-center justify-between border border-blue-200 rounded-lg p-4 bg-gray-50">
-            <div className="flex items-center gap-4">
-              <div className="w-10 h-10 flex items-center justify-center rounded-lg bg-white border border-blue-200">
-                📄
-              </div>
-              <div>
-                <p className="text-sm font-medium text-gray-900">
-                  Previous Marksheet
-                </p>
-                <span className="inline-block mt-1 px-2 py-[2px] text-xs font-medium text-blue-600 border border-blue-300 rounded-full">
-                  PDF
-                </span>
-              </div>
-            </div>
-            <div className="flex items-center gap-2 text-gray-500 text-sm cursor-pointer hover:text-blue-600">
-              👁
-              <span>View</span>
-            </div>
-          </div>
-
-          {/* Birth Certificate */}
-          <div className="flex items-center justify-between border border-blue-200 rounded-lg p-4 bg-gray-50">
-            <div className="flex items-center gap-4">
-              <div className="w-10 h-10 flex items-center justify-center rounded-lg bg-white border border-blue-200">
-                📄
-              </div>
-              <div>
-                <p className="text-sm font-medium text-gray-900">
-                  Birth Certificate
-                </p>
-                <span className="inline-block mt-1 px-2 py-[2px] text-xs font-medium text-blue-600 border border-blue-300 rounded-full">
-                  PDF
-                </span>
-              </div>
-            </div>
-            <div className="flex items-center gap-2 text-gray-500 text-sm cursor-pointer hover:text-blue-600">
-              👁
-              <span>View</span>
-            </div>
-          </div>
-
-          {/* Transfer Certificate */}
-          <div className="flex items-center justify-between border border-blue-200 rounded-lg p-4 bg-gray-50">
-            <div className="flex items-center gap-4">
-              <div className="w-10 h-10 flex items-center justify-center rounded-lg bg-white border border-blue-200">
-                📄
-              </div>
-              <div>
-                <p className="text-sm font-medium text-gray-900">
-                  Transfer Certificate
-                </p>
-                <span className="inline-block mt-1 px-2 py-[2px] text-xs font-medium text-blue-600 border border-blue-300 rounded-full">
-                  PDF
-                </span>
-              </div>
-            </div>
-            <div className="flex items-center gap-2 text-gray-500 text-sm cursor-pointer hover:text-blue-600">
-              👁
-              <span>View</span>
-            </div>
-          </div>
-        </div>
-      </div>
+      {typeof studentId === "string" ? (
+        <StudentProfileDocuments studentId={studentId} />
+      ) : null}
       <div className="flex w-full p-3 md:p-6">
         <p className="texr-[10px] text-[#737373] font-[600] text-center mx-auto">
           If any information is incorrect, please contact the accounts

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -30,6 +30,9 @@ export const ADMIN_API = {
   ANNOUNCEMENTS: "/admin/announcements",
   GRAPH: "/admin/attendance/graph",
   CLASS_DASHBOARD: "/admin/classes/dashboard",
+  DOCUMENTS: "/admin/documents",
+  DOCUMENTS_UPLOAD: "/admin/documents/upload",
+  DOCUMENT_BY_ID: (id: string) => `/admin/documents/${id}`,
 };
 
 export const TEACHER_API = {
@@ -52,6 +55,8 @@ export const STUDENT_API = {
   CHANGE_PASSWORD: "/api/student/auth/change-password",
   /** Admin-facing student profile by id */
   BY_ID: (id: string) => `/admin/students/${id}`,
+  /** Update student (admin or class teacher) */
+  UPDATE: (id: string) => `/students/${id}`,
 };
 
 const routes = {

--- a/src/modules/documents/api/documents.ts
+++ b/src/modules/documents/api/documents.ts
@@ -1,0 +1,159 @@
+import type { AxiosRequestConfig } from "axios";
+import { ADMIN_API } from "@/config/api-routes";
+import API from "@/services/axios";
+import type {
+  EntityDocument,
+  GetDocumentsParams,
+  UploadDocumentParams,
+} from "../types";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function pickString(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return "";
+}
+
+function pickNumber(...values: unknown[]): number | null {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim() && !Number.isNaN(Number(value))) {
+      return Number(value);
+    }
+  }
+  return null;
+}
+
+function normalizeDocument(raw: unknown): EntityDocument | null {
+  const obj = asRecord(raw);
+  const id = pickString(obj.id, obj._id, obj.documentId);
+  const url = pickString(
+    obj.url,
+    obj.fileUrl,
+    obj.file_url,
+    obj.documentUrl,
+    obj.document_url,
+  );
+  const documentType = pickString(
+    obj.documentType,
+    obj.document_type,
+    obj.type,
+  );
+  const entityId = pickString(obj.entityId, obj.entity_id);
+  const entityType = pickString(obj.entityType, obj.entity_type);
+
+  if (!url && !id) return null;
+
+  return {
+    id: id || url,
+    entityType,
+    entityId,
+    documentType,
+    url,
+    fileName: (pickString(obj.fileName, obj.file_name) || null) as string | null,
+    originalName: (pickString(
+      obj.originalName,
+      obj.original_name,
+      obj.name,
+    ) || null) as string | null,
+    mimeType: (pickString(obj.mimeType, obj.mime_type, obj.contentType) ||
+      null) as string | null,
+    size: pickNumber(obj.size, obj.fileSize, obj.file_size),
+    createdAt: (pickString(obj.createdAt, obj.created_at) || null) as
+      | string
+      | null,
+  };
+}
+
+function extractDocumentList(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) return payload;
+  const data = asRecord(payload);
+  if (Array.isArray(data.data)) return data.data;
+  if (Array.isArray(data.documents)) return data.documents;
+  if (Array.isArray(data.items)) return data.items;
+  if (data.data && typeof data.data === "object" && !Array.isArray(data.data)) {
+    return [data.data];
+  }
+  if (Object.keys(data).length > 0 && (data.url || data.fileUrl || data.id)) {
+    return [data];
+  }
+  return [];
+}
+
+export async function getDocuments(
+  params: GetDocumentsParams,
+  config?: AxiosRequestConfig,
+): Promise<EntityDocument[]> {
+  const query: Record<string, string> = {
+    entityType: params.entityType,
+    entityId: params.entityId,
+  };
+  if (params.documentType) query.documentType = params.documentType;
+
+  const res = await API.get(ADMIN_API.DOCUMENTS, {
+    params: query,
+    ...(config ?? {}),
+  });
+
+  return extractDocumentList(res.data)
+    .map(normalizeDocument)
+    .filter((doc): doc is EntityDocument => Boolean(doc));
+}
+
+export async function uploadDocument(
+  params: UploadDocumentParams,
+  config?: AxiosRequestConfig,
+): Promise<EntityDocument> {
+  const formData = new FormData();
+  formData.append("file", params.file);
+  formData.append("entityType", params.entityType);
+  formData.append("entityId", params.entityId);
+  formData.append("documentType", params.documentType);
+
+  const res = await API.post(ADMIN_API.DOCUMENTS_UPLOAD, formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+    ...(config ?? {}),
+  });
+
+  const list = extractDocumentList(res.data)
+    .map(normalizeDocument)
+    .filter((doc): doc is EntityDocument => Boolean(doc));
+
+  if (list[0]) return list[0];
+
+  const normalized = normalizeDocument(res.data);
+  if (normalized) return normalized;
+
+  return {
+    id: `${params.entityId}-${params.documentType}-${Date.now()}`,
+    entityType: params.entityType,
+    entityId: params.entityId,
+    documentType: params.documentType,
+    url: pickString(
+      asRecord(res.data).url,
+      asRecord(res.data).fileUrl,
+      asRecord(asRecord(res.data).data).url,
+      asRecord(asRecord(res.data).data).fileUrl,
+    ),
+    fileName: params.file.name,
+    originalName: params.file.name,
+    mimeType: params.file.type,
+    size: params.file.size,
+    createdAt: null,
+  };
+}
+
+export async function deleteDocument(
+  documentId: string,
+  config?: AxiosRequestConfig,
+): Promise<void> {
+  await API.delete(ADMIN_API.DOCUMENT_BY_ID(documentId), {
+    ...(config ?? {}),
+  });
+}

--- a/src/modules/documents/components/EntityDocumentsSection.tsx
+++ b/src/modules/documents/components/EntityDocumentsSection.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { Eye, Trash2, Upload } from "lucide-react";
+import type {
+  DocumentTypeOption,
+  EntityDocument,
+  UploadingDoc,
+} from "../types";
+
+type Props = {
+  title?: string;
+  documentTypes: readonly DocumentTypeOption[];
+  selectedDocumentType: string;
+  onDocumentTypeChange: (value: string) => void;
+  documents: EntityDocument[];
+  uploading: UploadingDoc[];
+  deletingIds?: string[];
+  loading?: boolean;
+  onUpload: (files: FileList | null) => void;
+  onDelete: (documentId: string) => void;
+  getLabelForType: (documentType: string) => string;
+};
+
+function fileExtensionLabel(doc: EntityDocument): string {
+  if (doc.mimeType?.includes("pdf")) return "PDF";
+  if (doc.mimeType?.includes("jpeg") || doc.mimeType?.includes("jpg"))
+    return "JPG";
+  if (doc.mimeType?.includes("png")) return "PNG";
+  const fromName = (doc.originalName || doc.fileName || "")
+    .split(".")
+    .pop()
+    ?.toUpperCase();
+  if (fromName && fromName.length <= 4) return fromName;
+  const fromUrl = doc.url.split(".").pop()?.split("?")[0]?.toUpperCase();
+  if (fromUrl && fromUrl.length <= 4) return fromUrl;
+  return "FILE";
+}
+
+function formatFileSize(bytes?: number | null): string | null {
+  if (bytes == null || !Number.isFinite(bytes) || bytes < 0) return null;
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatUploadedAt(value?: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export default function EntityDocumentsSection({
+  title = "Uploaded Documents",
+  documentTypes,
+  selectedDocumentType,
+  onDocumentTypeChange,
+  documents,
+  uploading,
+  deletingIds = [],
+  loading = false,
+  onUpload,
+  onDelete,
+  getLabelForType,
+}: Props) {
+  return (
+    <div className="w-full max-w-full bg-white rounded-xl border border-blue-200 p-[20px]">
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">{title}</h2>
+
+      <div
+        onDrop={(e) => {
+          e.preventDefault();
+          onUpload(e.dataTransfer.files);
+        }}
+        onDragOver={(e) => e.preventDefault()}
+        className="mb-5 flex flex-col items-center justify-center rounded-lg border border-dashed border-[#C5D6F5] bg-[#F9FBFF] px-6 py-8 text-center"
+      >
+        <Upload className="h-5 w-5 text-[#64748B]" />
+        <p className="mt-2 text-sm text-[#64748B]">
+          Click to upload or drag and drop
+        </p>
+        <p className="text-xs text-[#94A3B8]">PDF, JPG, or PNG (Max size: 5MB)</p>
+
+        <div className="mt-4 flex w-full max-w-md flex-col gap-3 sm:flex-row sm:items-center">
+          <label className="sr-only" htmlFor="entity-document-type">
+            Document type
+          </label>
+          <select
+            id="entity-document-type"
+            value={selectedDocumentType}
+            onChange={(e) => onDocumentTypeChange(e.target.value)}
+            className="w-full rounded-md border border-[#D7E3FC] bg-white px-3 py-2 text-sm text-[#0F172A]"
+          >
+            {documentTypes.map((type) => (
+              <option key={type.value} value={type.value}>
+                {type.label}
+              </option>
+            ))}
+          </select>
+          <input
+            type="file"
+            accept=".pdf,image/png,image/jpeg"
+            className="w-full text-sm"
+            onChange={(e) => onUpload(e.target.files)}
+          />
+        </div>
+      </div>
+
+      {uploading.length > 0 ? (
+        <div className="mb-4 space-y-2">
+          {uploading.map((doc, idx) => (
+            <div
+              key={`${doc.name}-${idx}`}
+              className="flex items-center justify-between rounded-md border border-dashed border-[#D7E3FC] bg-slate-50 px-3 py-2 text-sm"
+            >
+              <span className="text-[#0F172A]">
+                {doc.name}
+                {doc.documentType
+                  ? ` · ${getLabelForType(doc.documentType)}`
+                  : ""}
+              </span>
+              <span className="text-xs text-slate-500">
+                {doc.status === "uploading" ? "Uploading..." : doc.error}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <p className="text-sm text-slate-500">Loading documents...</p>
+      ) : documents.length === 0 ? (
+        <p className="text-sm text-slate-500">No documents uploaded yet.</p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {documents.map((doc) => {
+            const sizeLabel = formatFileSize(doc.size);
+            const uploadedAt = formatUploadedAt(doc.createdAt);
+            const isDeleting = deletingIds.includes(doc.id);
+
+            return (
+              <div
+                key={doc.id || `${doc.documentType}-${doc.url}`}
+                className="flex items-start justify-between gap-3 border border-blue-200 rounded-lg p-4 bg-gray-50"
+              >
+                <div className="flex items-start gap-4 min-w-0">
+                  <div className="w-10 h-10 flex items-center justify-center rounded-lg bg-white border border-blue-200 shrink-0 mt-0.5">
+                    📄
+                  </div>
+                  <div className="min-w-0 space-y-1">
+                    <p className="text-sm font-medium text-gray-900 truncate">
+                      {doc.originalName || doc.fileName || "Document"}
+                    </p>
+                    <p className="text-xs text-[#64748B]">
+                      {getLabelForType(doc.documentType)}
+                      {sizeLabel ? ` · ${sizeLabel}` : ""}
+                      {uploadedAt ? ` · ${uploadedAt}` : ""}
+                    </p>
+                    <span className="inline-block px-2 py-[2px] text-xs font-medium text-blue-600 border border-blue-300 rounded-full">
+                      {fileExtensionLabel(doc)}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2 shrink-0">
+                  {doc.url ? (
+                    <a
+                      href={doc.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1.5 text-gray-500 text-sm hover:text-blue-600"
+                    >
+                      <Eye className="h-4 w-4" />
+                      <span>View</span>
+                    </a>
+                  ) : null}
+                  <button
+                    type="button"
+                    disabled={isDeleting || !doc.id}
+                    onClick={() => onDelete(doc.id)}
+                    className="flex items-center gap-1.5 text-sm text-[#E11D48] hover:text-red-700 disabled:opacity-50"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    <span>{isDeleting ? "Deleting..." : "Delete"}</span>
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/modules/documents/constants/index.ts
+++ b/src/modules/documents/constants/index.ts
@@ -1,8 +1,25 @@
 export const MAX_DOCUMENT_FILE_SIZE = 5 * 1024 * 1024;
+
 export const ACCEPTED_DOCUMENT_TYPES = [
   "application/pdf",
   "image/jpeg",
   "image/png",
 ] as const;
 
+/** @deprecated Prefer ADMIN_API.DOCUMENTS_UPLOAD via documents API helpers */
 export const DOCUMENT_UPLOAD_PATH = "/api/uploads";
+
+export const DOCUMENT_ENTITY_TYPES = ["STUDENT", "TEACHER"] as const;
+
+/** Allowed API values for documentType */
+export const DOCUMENT_TYPES = [
+  { value: "PROFILE_PHOTO", label: "Profile Photo" },
+  { value: "ID_PROOF", label: "ID Proof" },
+  { value: "BIRTH_CERTIFICATE", label: "Birth Certificate" },
+  { value: "MARKSHEET", label: "Marksheet" },
+  { value: "CERTIFICATE", label: "Certificate" },
+  { value: "OTHER", label: "Other" },
+] as const;
+
+export const STUDENT_DOCUMENT_TYPES = DOCUMENT_TYPES;
+export const TEACHER_DOCUMENT_TYPES = DOCUMENT_TYPES;

--- a/src/modules/documents/hooks/useEntityDocuments.ts
+++ b/src/modules/documents/hooks/useEntityDocuments.ts
@@ -1,0 +1,201 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  deleteDocument,
+  getDocuments,
+  uploadDocument,
+} from "../api/documents";
+import {
+  ACCEPTED_DOCUMENT_TYPES,
+  MAX_DOCUMENT_FILE_SIZE,
+} from "../constants";
+import type {
+  DocumentEntityType,
+  DocumentTypeOption,
+  EntityDocument,
+  UploadingDoc,
+} from "../types";
+
+type UseEntityDocumentsOptions = {
+  entityType: DocumentEntityType;
+  entityId: string;
+  documentTypes: readonly DocumentTypeOption[];
+  /** Optional filter — omit to load all documents for the entity in one request. */
+  documentType?: string;
+};
+
+export function useEntityDocuments({
+  entityType,
+  entityId,
+  documentTypes,
+  documentType,
+}: UseEntityDocumentsOptions) {
+  const { toast } = useToast();
+  const [documents, setDocuments] = useState<EntityDocument[]>([]);
+  const [uploading, setUploading] = useState<UploadingDoc[]>([]);
+  const [deletingIds, setDeletingIds] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedDocumentType, setSelectedDocumentType] = useState(
+    documentTypes[0]?.value ?? "",
+  );
+
+  const refreshDocuments = useCallback(async () => {
+    if (!entityId) return;
+    setLoading(true);
+    try {
+      const list = await getDocuments({
+        entityType,
+        entityId,
+        ...(documentType ? { documentType } : {}),
+      });
+      setDocuments(list);
+    } catch (error) {
+      toast({
+        title: "Failed to load documents",
+        description:
+          error instanceof Error ? error.message : "Please try again",
+        type: "error",
+      });
+    } finally {
+      setLoading(false);
+    }
+    // toast identity changes every provider render — omit from deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [documentType, entityId, entityType]);
+
+  useEffect(() => {
+    void refreshDocuments();
+  }, [refreshDocuments]);
+
+  useEffect(() => {
+    if (
+      documentTypes.length > 0 &&
+      !documentTypes.some((t) => t.value === selectedDocumentType)
+    ) {
+      setSelectedDocumentType(documentTypes[0].value);
+    }
+  }, [documentTypes, selectedDocumentType]);
+
+  const handleDocumentUpload = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    if (!selectedDocumentType) {
+      toast({
+        title: "Select a document type",
+        description: "Choose which document you are uploading",
+        type: "error",
+      });
+      return;
+    }
+    if (!entityId) return;
+
+    const pending: UploadingDoc[] = [];
+    const uploads: Array<Promise<void>> = [];
+
+    Array.from(files).forEach((file) => {
+      if (
+        !ACCEPTED_DOCUMENT_TYPES.includes(
+          file.type as (typeof ACCEPTED_DOCUMENT_TYPES)[number],
+        )
+      ) {
+        toast({
+          title: "Unsupported file type",
+          description: "Only PDF, JPG, PNG allowed",
+          type: "error",
+        });
+        return;
+      }
+      if (file.size > MAX_DOCUMENT_FILE_SIZE) {
+        toast({
+          title: "File too large",
+          description: "Max size is 5MB per file",
+          type: "error",
+        });
+        return;
+      }
+
+      const temp: UploadingDoc = {
+        name: file.name,
+        status: "uploading",
+        documentType: selectedDocumentType,
+      };
+      pending.push(temp);
+
+      uploads.push(
+        uploadDocument({
+          file,
+          entityType,
+          entityId,
+          documentType: selectedDocumentType,
+        })
+          .then((doc) => {
+            temp.status = "done";
+            temp.url = doc.url;
+            setDocuments((prev) => [...prev, doc]);
+            toast({
+              title: "Document uploaded",
+              type: "success",
+            });
+          })
+          .catch((error) => {
+            temp.status = "error";
+            temp.error =
+              error instanceof Error ? error.message : "Upload failed";
+            toast({
+              title: "Upload failed",
+              description: temp.error,
+              type: "error",
+            });
+          }),
+      );
+    });
+
+    setUploading((prev) => [...prev, ...pending]);
+    await Promise.all(uploads);
+    setUploading((prev) => {
+      const existingErrors = prev.filter((p) => p.status === "error");
+      const newErrors = pending.filter((p) => p.status === "error");
+      return [...existingErrors, ...newErrors];
+    });
+  };
+
+  const handleDocumentDelete = async (documentId: string) => {
+    if (!documentId) return;
+    setDeletingIds((prev) => [...prev, documentId]);
+    try {
+      await deleteDocument(documentId);
+      setDocuments((prev) => prev.filter((d) => d.id !== documentId));
+      toast({
+        title: "Document deleted",
+        type: "success",
+      });
+    } catch (error) {
+      toast({
+        title: "Delete failed",
+        description:
+          error instanceof Error ? error.message : "Please try again",
+        type: "error",
+      });
+    } finally {
+      setDeletingIds((prev) => prev.filter((id) => id !== documentId));
+    }
+  };
+
+  const getLabelForType = (documentTypeValue: string) =>
+    documentTypes.find((t) => t.value === documentTypeValue)?.label ??
+    documentTypeValue;
+
+  return {
+    documents,
+    uploading,
+    deletingIds,
+    loading,
+    selectedDocumentType,
+    setSelectedDocumentType,
+    handleDocumentUpload,
+    handleDocumentDelete,
+    refreshDocuments,
+    getLabelForType,
+  };
+}

--- a/src/modules/documents/index.ts
+++ b/src/modules/documents/index.ts
@@ -1,9 +1,30 @@
-export type { StudentDocument, UploadingDoc, DocumentItem } from "./types";
+export type {
+  StudentDocument,
+  UploadingDoc,
+  DocumentItem,
+  DocumentEntityType,
+  DocumentType,
+  EntityDocument,
+  GetDocumentsParams,
+  UploadDocumentParams,
+  DocumentTypeOption,
+} from "./types";
 export { useStudentDocuments } from "./hooks/useStudentDocuments";
+export { useEntityDocuments } from "./hooks/useEntityDocuments";
 export { default as DocumentsGrid } from "./components/DocumentsGrid";
 export { default as StudentDocumentsSection } from "./components/StudentDocumentsSection";
+export { default as EntityDocumentsSection } from "./components/EntityDocumentsSection";
+export {
+  getDocuments,
+  uploadDocument,
+  deleteDocument,
+} from "./api/documents";
 export {
   MAX_DOCUMENT_FILE_SIZE,
   ACCEPTED_DOCUMENT_TYPES,
   DOCUMENT_UPLOAD_PATH,
+  DOCUMENT_ENTITY_TYPES,
+  DOCUMENT_TYPES,
+  STUDENT_DOCUMENT_TYPES,
+  TEACHER_DOCUMENT_TYPES,
 } from "./constants";

--- a/src/modules/documents/types/index.ts
+++ b/src/modules/documents/types/index.ts
@@ -1,3 +1,8 @@
+import {
+  DOCUMENT_ENTITY_TYPES,
+  DOCUMENT_TYPES,
+} from "../constants";
+
 export type StudentDocument = {
   document_type: string;
   url: string;
@@ -8,6 +13,7 @@ export type UploadingDoc = {
   status: "uploading" | "error" | "done";
   url?: string;
   error?: string;
+  documentType?: string;
 };
 
 export type DocumentItem = {
@@ -15,4 +21,41 @@ export type DocumentItem = {
   title: string;
   type?: string;
   href?: string;
+};
+
+export type DocumentEntityType = (typeof DOCUMENT_ENTITY_TYPES)[number];
+
+export type DocumentType = (typeof DOCUMENT_TYPES)[number]["value"];
+export type StudentDocumentType = DocumentType;
+export type TeacherDocumentType = DocumentType;
+
+export type EntityDocument = {
+  id: string;
+  entityType: DocumentEntityType | string;
+  entityId: string;
+  documentType: string;
+  url: string;
+  fileName?: string | null;
+  originalName?: string | null;
+  mimeType?: string | null;
+  size?: number | null;
+  createdAt?: string | null;
+};
+
+export type GetDocumentsParams = {
+  entityType: DocumentEntityType;
+  entityId: string;
+  documentType?: string;
+};
+
+export type UploadDocumentParams = {
+  file: File;
+  entityType: DocumentEntityType;
+  entityId: string;
+  documentType: string;
+};
+
+export type DocumentTypeOption = {
+  value: string;
+  label: string;
 };

--- a/src/modules/students/api/adminStudents.ts
+++ b/src/modules/students/api/adminStudents.ts
@@ -1,5 +1,5 @@
 import type { StudentsQuery, StudentsResponse } from "@/modules/students/types/admin";
-import { ADMIN_API } from "@/config/api-routes";
+import { ADMIN_API, STUDENT_API } from "@/config/api-routes";
 import API from "@/services/axios";
 
 export type {
@@ -85,19 +85,22 @@ export async function createStudent(payload: CreateStudentPayload) {
 }
 
 export type UpdateStudentPayload = {
-  email: string;
-  fullName: string;
-  phoneNumber: string;
-  gender: string;
-  category: string;
-  admissionDate: string | null;
-  addressLine: string;
-  aadhaarNumber: string;
-  fatherName: string;
-  fatherMobile: string;
-  motherName: string;
-  parentEmail: string;
-  documentUrls: string[];
+  firstName: string;
+  lastName: string;
+  phoneNumber?: string;
+  gender?: "MALE" | "FEMALE" | "OTHER";
+  admissionDate?: string;
+  classId?: string;
+  addressLine?: string;
+  aadhaarNumber?: string;
+  fatherName?: string;
+  fatherMobile?: string;
+  motherName?: string;
+  motherMobile?: string;
+  guardianName?: string;
+  guardianMobile?: string;
+  bloodGroup?: string;
+  medicalNotes?: string;
 };
 
 export async function updateStudent(
@@ -105,7 +108,7 @@ export async function updateStudent(
   payload: UpdateStudentPayload,
   options?: { signal?: AbortSignal },
 ) {
-  const res = await API.put(`/api/admin/students/${studentId}`, payload, {
+  const res = await API.patch(STUDENT_API.UPDATE(studentId), payload, {
     signal: options?.signal,
   });
   return res.data;

--- a/src/modules/students/components/StudentProfileDocuments.tsx
+++ b/src/modules/students/components/StudentProfileDocuments.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import {
+  EntityDocumentsSection,
+  STUDENT_DOCUMENT_TYPES,
+  useEntityDocuments,
+} from "@/modules/documents";
+
+type Props = {
+  studentId: string;
+};
+
+export default function StudentProfileDocuments({ studentId }: Props) {
+  const {
+    documents,
+    uploading,
+    deletingIds,
+    loading,
+    selectedDocumentType,
+    setSelectedDocumentType,
+    handleDocumentUpload,
+    handleDocumentDelete,
+    getLabelForType,
+  } = useEntityDocuments({
+    entityType: "STUDENT",
+    entityId: studentId,
+    documentTypes: STUDENT_DOCUMENT_TYPES,
+  });
+
+  return (
+    <EntityDocumentsSection
+      title="Uploaded Documents"
+      documentTypes={STUDENT_DOCUMENT_TYPES}
+      selectedDocumentType={selectedDocumentType}
+      onDocumentTypeChange={setSelectedDocumentType}
+      documents={documents}
+      uploading={uploading}
+      deletingIds={deletingIds}
+      loading={loading}
+      onUpload={handleDocumentUpload}
+      onDelete={handleDocumentDelete}
+      getLabelForType={getLabelForType}
+    />
+  );
+}

--- a/src/modules/students/components/UpdateStudentDialog.tsx
+++ b/src/modules/students/components/UpdateStudentDialog.tsx
@@ -1,22 +1,28 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2, X } from "lucide-react";
 import { updateStudent } from "@/modules/students/api/adminStudents";
 import { useToast } from "@/components/ui/use-toast";
 import Button from "@/components/ui/Button";
 import { Form } from "@/components/ui/Form";
 import GuardianInformationSection from "./student-form/GuardianInformationSection";
-import { StudentDocumentsSection } from "@/modules/documents";
+import {
+  EntityDocumentsSection,
+  STUDENT_DOCUMENT_TYPES,
+  useEntityDocuments,
+} from "@/modules/documents";
 import StudentInformationSection from "./student-form/StudentInformationSection";
 import StudentLoadError from "./student-form/StudentLoadError";
 import UpdateStudentSkeleton from "./student-form/UpdateStudentSkeleton";
-import { cleanDigits, toLower } from "@/modules/students/utils/formatters";
-import { useStudentDocuments } from "@/modules/documents";
+import { cleanDigits, formatGenderForApi } from "@/modules/students/utils/formatters";
 import { useStudentProfileLoader } from "@/modules/students/hooks/useStudentProfileLoader";
+import type { UpdateStudentPayload } from "@/modules/students/api/adminStudents";
 import {
   updateStudentDefaultValues,
+  updateStudentSchema,
   type UpdateStudentForm,
 } from "@/modules/students/schemas/updateStudentSchema";
 
@@ -40,18 +46,27 @@ export default function UpdateStudentDialog({
   const submitController = useRef<AbortController | null>(null);
 
   const form = useForm<UpdateStudentForm>({
-    // resolver: zodResolver(updateStudentSchema),
+    resolver: zodResolver(updateStudentSchema),
+    mode: "onSubmit",
+    reValidateMode: "onChange",
     defaultValues: updateStudentDefaultValues,
   });
 
   const {
     documents,
-    setDocuments,
     uploading,
+    deletingIds,
+    loading: documentsLoading,
+    selectedDocumentType,
+    setSelectedDocumentType,
     handleDocumentUpload,
-    removeDocument,
-    resetDocuments,
-  } = useStudentDocuments();
+    handleDocumentDelete,
+    getLabelForType,
+  } = useEntityDocuments({
+    entityType: "STUDENT",
+    entityId: open && studentId ? studentId : "",
+    documentTypes: STUDENT_DOCUMENT_TYPES,
+  });
 
   const {
     loading,
@@ -62,74 +77,65 @@ export default function UpdateStudentDialog({
     studentIdDisplay,
     retry,
     abortFetch,
-  } = useStudentProfileLoader({ open, studentId, form, setDocuments });
+  } = useStudentProfileLoader({ open, studentId, form });
 
   const handleClose = () => {
     abortFetch();
     submitController.current?.abort();
     form.reset();
-    resetDocuments();
     setFetchError(null);
     onClose();
   };
 
-  useEffect(() => {
-    form.setValue("student_documents", documents);
-  }, [documents, form]);
-
   const onSubmit = async (values: UpdateStudentForm) => {
     if (!studentId) return;
-    console.log("Submitting form with values:", values);
     setSubmitting(true);
     submitController.current?.abort();
     const controller = new AbortController();
     submitController.current = controller;
 
-    const payload = {
-      email: toLower(values.email),
-      fullName: values.name.trim(),
-      phoneNumber: cleanDigits(values.phone_no),
-      gender: values.gender,
-      category: values.category,
-      admissionDate: values.admission_date,
-      addressLine: values.address.trim(),
-      aadhaarNumber: cleanDigits(values.aadhar),
-      fatherName: values.guardian.father_name.trim(),
-      fatherMobile: cleanDigits(values.guardian.phone_no),
-      motherName: values.guardian.mother_name?.trim() || "",
-      parentEmail: toLower(values.guardian.email),
-      documentUrls: documents.map((d) => d.url),
+    const payload: UpdateStudentPayload = {
+      firstName: values.firstName.trim(),
+      lastName: values.lastName.trim(),
+      phoneNumber: cleanDigits(values.phone_no ?? "") || undefined,
+      gender: formatGenderForApi(values.gender),
+      admissionDate: values.admission_date || undefined,
+      classId: values.classId?.trim() || undefined,
+      addressLine: values.address?.trim() || undefined,
+      aadhaarNumber: cleanDigits(values.aadhar ?? "") || undefined,
+      fatherName: values.father_name?.trim() || undefined,
+      fatherMobile: cleanDigits(values.father_mobile ?? "") || undefined,
+      motherName: values.mother_name?.trim() || undefined,
+      motherMobile: cleanDigits(values.mother_mobile ?? "") || undefined,
+      guardianName: values.guardian_name?.trim() || undefined,
+      guardianMobile: cleanDigits(values.guardian_mobile ?? "") || undefined,
+      bloodGroup: values.bloodGroup?.trim() || undefined,
+      medicalNotes: values.medicalNotes?.trim() || undefined,
     };
 
     try {
-      // DEBUG: log payload before sending
-      // eslint-disable-next-line no-console
-      console.debug("Updating student", { studentId, payload });
-
       await updateStudent(studentId, payload, {
         signal: controller.signal,
       });
-
-      // DEBUG: log response and status
-      // eslint-disable-next-line no-console
-      console.debug("Update response", "ok");
 
       toast({ title: "Student updated successfully", type: "success" });
       onUpdated?.();
       handleClose();
     } catch (err: unknown) {
-      // eslint-disable-next-line no-console
-      console.error("Update error", err);
-      if ((err as any)?.code === "ERR_CANCELED") return;
-      if ((err as any)?.response?.data) {
-        const data = (err as any).response.data as Record<string, any>;
-        // eslint-disable-next-line no-console
-        console.debug("Server error body", data);
+      if ((err as { code?: string })?.code === "ERR_CANCELED") return;
+      const axiosErr = err as {
+        response?: { data?: Record<string, unknown> };
+        message?: string;
+      };
+      if (axiosErr?.response?.data) {
+        const data = axiosErr.response.data;
         if (data?.fieldErrors && typeof data.fieldErrors === "object") {
           Object.entries(data.fieldErrors as Record<string, string>).forEach(
             ([key, message]) => {
-              const path = key.replace("guardian.", "guardian.");
-              form.setError(path as any, { type: "server", message });
+              form.setError(key as keyof UpdateStudentForm, {
+                type: "server",
+                message,
+              });
             },
           );
         }
@@ -159,7 +165,6 @@ export default function UpdateStudentDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      {/* Overlay */}
       <div className="absolute inset-0 bg-black/40" onClick={handleClose} />
       <div className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden">
         <div className="absolute inset-0 bg-black/40" onClick={handleClose} />
@@ -169,10 +174,10 @@ export default function UpdateStudentDialog({
               <div className="flex items-start sticky top-0 bg-[#021034] rounded-t-lg py-[24px] px-[16px] justify-between gap-4">
                 <div className="space-y-1">
                   <h1 className="text-2xl font-bold text-white">
-                    Create & Update Student
+                    Update Student
                   </h1>
                   <p className="text-sm text-white/80">
-                    Update and create new student information
+                    Update student information and documents
                   </p>
                 </div>
                 <button
@@ -198,7 +203,6 @@ export default function UpdateStudentDialog({
                       onSubmit={form.handleSubmit(onSubmit)}
                       className="space-y-6"
                     >
-                      {/* student_id and class_id are not submitted — display only */}
                       <StudentInformationSection
                         form={form}
                         classDisplay={classDisplay}
@@ -207,14 +211,25 @@ export default function UpdateStudentDialog({
                       />
 
                       <GuardianInformationSection form={form} />
-
-                      <StudentDocumentsSection
-                        documents={documents}
-                        uploading={uploading}
-                        onUpload={handleDocumentUpload}
-                        onRemove={removeDocument}
-                      />
                     </Form>
+
+                    {studentId ? (
+                      <div className="mt-6">
+                        <EntityDocumentsSection
+                          title="Student Documents"
+                          documentTypes={STUDENT_DOCUMENT_TYPES}
+                          selectedDocumentType={selectedDocumentType}
+                          onDocumentTypeChange={setSelectedDocumentType}
+                          documents={documents}
+                          uploading={uploading}
+                          deletingIds={deletingIds}
+                          loading={documentsLoading}
+                          onUpload={handleDocumentUpload}
+                          onDelete={handleDocumentDelete}
+                          getLabelForType={getLabelForType}
+                        />
+                      </div>
+                    ) : null}
                   </div>
                 )}
               </div>
@@ -226,12 +241,7 @@ export default function UpdateStudentDialog({
                   type="button"
                   variant="dark"
                   onClick={() => {
-                    // DEBUG: log click and current form values
-                    // eslint-disable-next-line no-console
-                    console.debug("Save button clicked", form.getValues());
-                    // Trigger RHF submit and log client-side validation errors
                     form.handleSubmit(onSubmit, (errs) => {
-                      // eslint-disable-next-line no-console
                       console.error("Client validation errors on click:", errs);
                     })();
                   }}

--- a/src/modules/students/components/student-form/GenderSelectField.tsx
+++ b/src/modules/students/components/student-form/GenderSelectField.tsx
@@ -31,9 +31,9 @@ export default function GenderSelectField({ form }: Props) {
           </SelectTrigger>
           <SelectContent>
             <SelectGroup>
-              <SelectItem value="male">Male</SelectItem>
-              <SelectItem value="female">Female</SelectItem>
-              <SelectItem value="other">Other</SelectItem>
+              <SelectItem value="MALE">Male</SelectItem>
+              <SelectItem value="FEMALE">Female</SelectItem>
+              <SelectItem value="OTHER">Other</SelectItem>
             </SelectGroup>
           </SelectContent>
         </Select>

--- a/src/modules/students/components/student-form/GuardianInformationSection.tsx
+++ b/src/modules/students/components/student-form/GuardianInformationSection.tsx
@@ -4,8 +4,8 @@ import React from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { FormField, FormLabel, FormMessage, FormControl } from "@/components/ui/Form";
 import { Input } from "@/components/ui/Input";
-import Textarea from "@/components/ui/Textarea";
 import FormSectionCard from "./FormSectionCard";
+import MobileInputField from "./MobileInputField";
 import type { UpdateStudentForm } from "@/modules/students/schemas/updateStudentSchema";
 
 type Props = {
@@ -16,72 +16,66 @@ export default function GuardianInformationSection({ form }: Props) {
   const { errors } = form.formState;
 
   return (
-    <FormSectionCard title="Parent Information">
+    <FormSectionCard title="Parent / Guardian Information">
       <FormField>
         <FormLabel>{"Father's Name"}</FormLabel>
         <FormControl>
           <Input
             placeholder="Full name"
-            {...form.register("guardian.father_name")}
+            {...form.register("father_name")}
           />
         </FormControl>
         <FormMessage>
-          {errors.guardian?.father_name?.message as React.ReactNode}
+          {errors.father_name?.message as React.ReactNode}
         </FormMessage>
       </FormField>
 
+      <MobileInputField
+        control={form.control}
+        name="father_mobile"
+        label="Father's Mobile"
+        error={errors.father_mobile?.message}
+      />
+
       <FormField>
-        <FormLabel>{"Mother's Name (Optional)"}</FormLabel>
+        <FormLabel>{"Mother's Name"}</FormLabel>
         <FormControl>
           <Input
             placeholder="Full name"
-            {...form.register("guardian.mother_name")}
+            {...form.register("mother_name")}
           />
         </FormControl>
         <FormMessage>
-          {errors.guardian?.mother_name?.message as React.ReactNode}
+          {errors.mother_name?.message as React.ReactNode}
         </FormMessage>
       </FormField>
 
+      <MobileInputField
+        control={form.control}
+        name="mother_mobile"
+        label="Mother's Mobile"
+        error={errors.mother_mobile?.message}
+      />
+
       <FormField>
-        <FormLabel>Emergency Contact Phone</FormLabel>
+        <FormLabel>Guardian Name</FormLabel>
         <FormControl>
           <Input
-            placeholder="Phone number"
-            {...form.register("guardian.phone_no")}
+            placeholder="Full name"
+            {...form.register("guardian_name")}
           />
         </FormControl>
         <FormMessage>
-          {errors.guardian?.phone_no?.message as React.ReactNode}
+          {errors.guardian_name?.message as React.ReactNode}
         </FormMessage>
       </FormField>
 
-      <FormField>
-        <FormLabel>Parent Email</FormLabel>
-        <FormControl>
-          <Input
-            placeholder="parent@gmail.com"
-            {...form.register("guardian.email")}
-          />
-        </FormControl>
-        <FormMessage>
-          {errors.guardian?.email?.message as React.ReactNode}
-        </FormMessage>
-      </FormField>
-
-      <FormField>
-        <FormLabel>Parent Permanent Address (Optional)</FormLabel>
-        <FormControl>
-          <Textarea
-            rows={3}
-            placeholder="Same as student address if blank"
-            {...form.register("guardian.address")}
-          />
-        </FormControl>
-        <FormMessage>
-          {errors.guardian?.address?.message as React.ReactNode}
-        </FormMessage>
-      </FormField>
+      <MobileInputField
+        control={form.control}
+        name="guardian_mobile"
+        label="Guardian Mobile"
+        error={errors.guardian_mobile?.message}
+      />
     </FormSectionCard>
   );
 }

--- a/src/modules/students/components/student-form/MobileInputField.tsx
+++ b/src/modules/students/components/student-form/MobileInputField.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import React from "react";
+import { Controller, type Control, type FieldPath } from "react-hook-form";
+import { FormField, FormLabel, FormMessage, FormControl } from "@/components/ui/Form";
+import {
+  cleanDigits,
+  formatMobileDisplay,
+} from "@/modules/students/utils/formatters";
+import type { UpdateStudentForm } from "@/modules/students/schemas/updateStudentSchema";
+
+type Props = {
+  control: Control<UpdateStudentForm>;
+  name: FieldPath<UpdateStudentForm>;
+  label: string;
+  error?: string;
+};
+
+/** +91 prefix with 10 digits shown as "XXXXX XXXXX". */
+export default function MobileInputField({
+  control,
+  name,
+  label,
+  error,
+}: Props) {
+  return (
+    <FormField>
+      <FormLabel>{label}</FormLabel>
+      <FormControl>
+        <Controller
+          control={control}
+          name={name}
+          render={({ field }) => (
+            <div className="flex w-full rounded-md border border-[#D7E3FC] text-[14px] text-[#64748B] font-[400] placeholder:text-[#6B7280] focus-within:ring-1 focus-within:ring-[#D7E3FC] focus-within:border-[#D7E3FC]">
+              <p className="border-r border-[#D7E3FC] px-2 py-2">+91</p>
+              <input
+                className="pl-2 w-full outline-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 bg-transparent"
+                type="text"
+                inputMode="numeric"
+                maxLength={11}
+                placeholder="98765 43210"
+                value={formatMobileDisplay(String(field.value ?? ""))}
+                onChange={(e) =>
+                  field.onChange(cleanDigits(e.target.value).slice(0, 10))
+                }
+                onBlur={field.onBlur}
+                name={field.name}
+                ref={field.ref}
+              />
+            </div>
+          )}
+        />
+      </FormControl>
+      <FormMessage>{error as React.ReactNode}</FormMessage>
+    </FormField>
+  );
+}

--- a/src/modules/students/components/student-form/StudentInformationSection.tsx
+++ b/src/modules/students/components/student-form/StudentInformationSection.tsx
@@ -1,14 +1,18 @@
 "use client";
 
 import React from "react";
-import type { UseFormReturn } from "react-hook-form";
+import { Controller, type UseFormReturn } from "react-hook-form";
 import { FormField, FormLabel, FormMessage, FormControl } from "@/components/ui/Form";
 import { Input } from "@/components/ui/Input";
 import Textarea from "@/components/ui/Textarea";
 import FormSectionCard from "./FormSectionCard";
 import GenderSelectField from "./GenderSelectField";
-import CategorySelectField from "./CategorySelectField";
 import AdmissionDateField from "./AdmissionDateField";
+import MobileInputField from "./MobileInputField";
+import {
+  cleanDigits,
+  formatAadharDisplay,
+} from "@/modules/students/utils/formatters";
 import type { UpdateStudentForm } from "@/modules/students/schemas/updateStudentSchema";
 
 type Props = {
@@ -27,15 +31,22 @@ export default function StudentInformationSection({
   return (
     <FormSectionCard title="Student Information">
       <FormField>
-        <FormLabel>Student Name</FormLabel>
+        <FormLabel>First Name</FormLabel>
         <FormControl>
-          <Input
-            placeholder="Search or select student..."
-            {...form.register("name")}
-          />
+          <Input placeholder="First name" {...form.register("firstName")} />
         </FormControl>
         <FormMessage>
-          {form.formState.errors.name?.message as React.ReactNode}
+          {form.formState.errors.firstName?.message as React.ReactNode}
+        </FormMessage>
+      </FormField>
+
+      <FormField>
+        <FormLabel>Last Name</FormLabel>
+        <FormControl>
+          <Input placeholder="Last name" {...form.register("lastName")} />
+        </FormControl>
+        <FormMessage>
+          {form.formState.errors.lastName?.message as React.ReactNode}
         </FormMessage>
       </FormField>
 
@@ -69,6 +80,8 @@ export default function StudentInformationSection({
         <FormControl>
           <Input
             placeholder="student@school.edu"
+            disabled
+            className="bg-[#F5F9FF]"
             {...form.register("email")}
           />
         </FormControl>
@@ -77,24 +90,26 @@ export default function StudentInformationSection({
         </FormMessage>
       </FormField>
 
-      <FormField>
-        <FormLabel>Phone Number</FormLabel>
-        <FormControl>
-          <Input
-            placeholder="Enter 10-digit number"
-            {...form.register("phone_no")}
-          />
-        </FormControl>
-        <FormMessage>
-          {form.formState.errors.phone_no?.message as React.ReactNode}
-        </FormMessage>
-      </FormField>
+      <MobileInputField
+        control={form.control}
+        name="phone_no"
+        label="Phone Number"
+        error={form.formState.errors.phone_no?.message}
+      />
 
       <GenderSelectField form={form} />
 
-      <CategorySelectField form={form} />
-
       <AdmissionDateField form={form} locked={admissionLocked} />
+
+      <FormField>
+        <FormLabel>Blood Group</FormLabel>
+        <FormControl>
+          <Input placeholder="e.g. O+" {...form.register("bloodGroup")} />
+        </FormControl>
+        <FormMessage>
+          {form.formState.errors.bloodGroup?.message as React.ReactNode}
+        </FormMessage>
+      </FormField>
 
       <FormField>
         <FormLabel>Home Address</FormLabel>
@@ -114,12 +129,45 @@ export default function StudentInformationSection({
       <FormField>
         <FormLabel>Aadhar Number</FormLabel>
         <FormControl>
-          <Input placeholder="12-digit number" {...form.register("aadhar")} />
+          <Controller
+            control={form.control}
+            name="aadhar"
+            render={({ field }) => (
+              <Input
+                type="tel"
+                inputMode="numeric"
+                maxLength={14}
+                value={formatAadharDisplay(field.value ?? "")}
+                onChange={(e) =>
+                  field.onChange(cleanDigits(e.target.value).slice(0, 12))
+                }
+                onBlur={field.onBlur}
+                placeholder="1234 5678 9012"
+              />
+            )}
+          />
         </FormControl>
         <FormMessage>
           {form.formState.errors.aadhar?.message as React.ReactNode}
         </FormMessage>
       </FormField>
+
+      <div className="md:col-span-2">
+        <FormField>
+          <FormLabel>Medical Notes</FormLabel>
+          <FormControl>
+            <Textarea
+              rows={3}
+              maxLength={500}
+              placeholder="Any medical notes or allergies"
+              {...form.register("medicalNotes")}
+            />
+          </FormControl>
+          <FormMessage>
+            {form.formState.errors.medicalNotes?.message as React.ReactNode}
+          </FormMessage>
+        </FormField>
+      </div>
     </FormSectionCard>
   );
 }

--- a/src/modules/students/hooks/useStudentProfileLoader.ts
+++ b/src/modules/students/hooks/useStudentProfileLoader.ts
@@ -1,26 +1,47 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { Dispatch, SetStateAction } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import API from "@/services/axios";
 import { STUDENT_API } from "@/config/api-routes";
-import type { StudentDocument, StudentProfileResponse } from "@/modules/students/types/form";
+import type { StudentProfileResponse } from "@/modules/students/types/form";
 import type { UpdateStudentForm } from "@/modules/students/schemas/updateStudentSchema";
+import {
+  cleanDigits,
+  normalizeGenderForForm,
+  normalizeMobileForForm,
+  splitFullName,
+} from "@/modules/students/utils/formatters";
 
 type Params = {
   open: boolean;
   studentId: string | null;
   form: UseFormReturn<UpdateStudentForm>;
-  setDocuments: Dispatch<SetStateAction<StudentDocument[]>>;
 };
 
-export function useStudentProfileLoader({
-  open,
-  studentId,
-  form,
-  setDocuments,
-}: Params) {
+function pickClassId(data: StudentProfileResponse): string {
+  if (typeof data.classId === "string" && data.classId) return data.classId;
+  if (typeof data.class_id === "string" && data.class_id) return data.class_id;
+  if (data.class_id && typeof data.class_id === "object") {
+    return (
+      data.class_id.id ??
+      (data.class_id as { classId?: string }).classId ??
+      ""
+    );
+  }
+  return "";
+}
+
+function pickClassName(data: StudentProfileResponse): string {
+  if (data.className?.trim()) return data.className;
+  if (data.class_name?.trim()) return data.class_name;
+  if (data.class_id && typeof data.class_id === "object") {
+    return data.class_id.name ?? data.class_id.className ?? "";
+  }
+  return "";
+}
+
+export function useStudentProfileLoader({ open, studentId, form }: Params) {
   const [loading, setLoading] = useState(false);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [classDisplay, setClassDisplay] = useState<string>("");
@@ -30,71 +51,54 @@ export function useStudentProfileLoader({
 
   const hydrateForm = useCallback(
     (data: StudentProfileResponse) => {
-      const admissionDate = data.admission_date
-        ? data.admission_date.split("T")[0]
+      const rawAdmission =
+        data.admissionDate ?? data.admission_date ?? null;
+      const admissionDate = rawAdmission
+        ? String(rawAdmission).split("T")[0]
         : "";
-      const locked = Boolean(data.admission_date);
-      // Ensure class_id is a string (API may sometimes return an object)
-      let classIdValue: string = "";
-      if (typeof data.class_id === "string") {
-        classIdValue = data.class_id;
-      } else if (data.class_id && typeof data.class_id === "object") {
-        // try common id keys
-        // eslint-disable-next-line no-console
-        console.warn(
-          "hydrateForm: class_id is an object, normalizing to string id",
-          data.class_id,
-        );
-        classIdValue =
-          (data.class_id as any).id ??
-          (data.class_id as any).classId ??
-          (data.class_id as any)._id ??
-          String(data.class_id);
-      }
+      const locked = Boolean(rawAdmission);
+      const { firstName, lastName } = splitFullName(data.name ?? "");
+      const classIdValue = pickClassId(data);
+      const classNameValue = pickClassName(data);
 
       form.reset({
-        name: data.name ?? "",
+        firstName,
+        lastName,
         email: data.email ?? "",
-        phone_no: data.phone_no ?? "",
-        gender: data.gender ?? "male",
-        category: data.category ?? "General",
+        phone_no: normalizeMobileForForm(data.phoneNo ?? data.phone_no),
+        gender: normalizeGenderForForm(data.gender),
+        category: data.category ?? "",
         admission_date: admissionDate,
+        classId: classIdValue,
         address: data.address ?? "",
-        aadhar: data.aadhar ?? "",
-        guardian: {
-          father_name: data.guardian?.father_name ?? "",
-          mother_name: data.guardian?.mother_name ?? "",
-          phone_no: data.guardian?.phone_no ?? "",
-          email: data.guardian?.email ?? "",
-          address: data.guardian?.address ?? "",
-        },
-        student_documents: data.student_documents ?? [],
-        class_name: data.class_name ?? "",
+        aadhar: cleanDigits(
+          data.aadhaarNumber ?? data.aadhaar ?? data.aadhar ?? "",
+        ).slice(0, 12),
+        father_name: data.fatherName ?? data.guardian?.father_name ?? "",
+        father_mobile: normalizeMobileForForm(
+          data.fatherMobile ?? data.guardian?.phone_no,
+        ),
+        mother_name: data.motherName ?? data.guardian?.mother_name ?? "",
+        mother_mobile: normalizeMobileForForm(data.motherMobile),
+        guardian_name: data.guardianName ?? "",
+        guardian_mobile: normalizeMobileForForm(data.guardianMobile),
+        bloodGroup: data.bloodGroup ?? "",
+        medicalNotes: data.medicalNotes ?? "",
+        class_name: classNameValue,
         admission_locked: locked,
       });
-      setDocuments(data.student_documents ?? []);
+
       setStudentIdDisplay(data.studentId ?? "");
-      // If API included a class display name use it, otherwise try to derive from object
-      if (data.class_name && data.class_name.trim()) {
-        setClassDisplay(data.class_name);
-      } else if (data.class_id && typeof data.class_id === "object") {
-        const cname =
-          (data.class_id as any).name ?? (data.class_id as any).className ?? "";
-        console.log(cname + "class name of student");
-        setClassDisplay(cname || "");
-      } else {
-        setClassDisplay("");
-      }
+      setClassDisplay(classNameValue);
       setAdmissionLocked(locked);
     },
-    [form, setDocuments],
+    [form],
   );
 
   useEffect(() => {
     if (!open || !studentId) return;
     setLoading(true);
     setFetchError(null);
-    setDocuments([]);
     fetchController.current?.abort();
     const controller = new AbortController();
     fetchController.current = controller;
@@ -106,7 +110,7 @@ export function useStudentProfileLoader({
         });
         hydrateForm(res.data as StudentProfileResponse);
       } catch (err: unknown) {
-        if ((err as any)?.code === "ERR_CANCELED") return;
+        if ((err as { code?: string })?.code === "ERR_CANCELED") return;
         const message =
           err instanceof Error ? err.message : "Failed to load student";
         setFetchError(message);
@@ -114,7 +118,7 @@ export function useStudentProfileLoader({
         setLoading(false);
       }
     })();
-  }, [open, studentId, hydrateForm, setDocuments]);
+  }, [open, studentId, hydrateForm]);
 
   const retry = useCallback(() => {
     if (!studentId) return;
@@ -123,11 +127,13 @@ export function useStudentProfileLoader({
     fetchController.current?.abort();
     const controller = new AbortController();
     fetchController.current = controller;
-    API.get(`/api/admin/students/${studentId}`, {
+    API.get(STUDENT_API.BY_ID(studentId), {
       signal: controller.signal,
     })
       .then((res) => hydrateForm(res.data as StudentProfileResponse))
-      .catch((err) => setFetchError(err?.message ?? "Failed to load"))
+      .catch((err: { message?: string }) =>
+        setFetchError(err?.message ?? "Failed to load"),
+      )
       .finally(() => setLoading(false));
   }, [studentId, hydrateForm]);
 

--- a/src/modules/students/index.ts
+++ b/src/modules/students/index.ts
@@ -18,6 +18,7 @@ export {
 export { useStudentProfileLoader } from "./hooks/useStudentProfileLoader";
 export { default as CreateStudentDialog } from "./components/CreateStudentDialog";
 export { default as UpdateStudentDialog } from "./components/UpdateStudentDialog";
+export { default as StudentProfileDocuments } from "./components/StudentProfileDocuments";
 export { default as StudentsTable } from "./components/StudentsTable";
 export {
   default as StudentsFilterBar,

--- a/src/modules/students/schemas/updateStudentSchema.ts
+++ b/src/modules/students/schemas/updateStudentSchema.ts
@@ -1,75 +1,63 @@
 import { z } from "zod";
 
 const nameRegex = /^[A-Za-z ]+$/;
+/** Indian mobile: exactly 10 digits, starting with 6–9 */
+const mobileRegex = /^[6-9]\d{9}$/;
 
-export const GENDER_VALUES = ["male", "female", "other"];
+const optionalMobile = z
+  .string()
+  .trim()
+  .refine((v) => v === "" || mobileRegex.test(v), {
+    message: "Enter a valid 10-digit mobile number",
+  });
+
+export const GENDER_VALUES = ["MALE", "FEMALE", "OTHER"] as const;
+export type GenderValue = (typeof GENDER_VALUES)[number];
 export const CATEGORY_VALUES = ["General", "OBC", "SC", "ST", "EWS"];
 
-export const guardianSchema = z.object({
-  father_name: z
-    .string()
-    .trim()
-    .min(3, "Father name must be at least 3 characters")
-    .max(100, "Too long"),
-  mother_name: z
-    .string()
-    .trim()
-    .min(3, "Mother name must be at least 3 characters")
-    .max(100, "Too long")
-    .optional()
-    .or(z.literal("")),
-  phone_no: z
-    .string()
-    .min(10, "Guardian phone must be 10-15 digits")
-    .max(15, "Guardian phone must be 10-15 digits")
-    .regex(/^[0-9]+$/, "Digits only"),
-  email: z.string().trim().email("Invalid guardian email"),
-  address: z
-    .string()
-    .trim()
-    .max(300, "Max 300 characters")
-    .optional()
-    .or(z.literal("")),
-});
-
-export const documentSchema = z.object({
-  document_type: z.string().min(1, "Document type is required").max(120),
-  url: z.string().url("Invalid document URL"),
-});
-
 export const updateStudentSchema = z.object({
-  name: z
+  firstName: z
     .string()
     .trim()
-    .min(3, "Name must be at least 3 characters")
-    .max(100, "Name must be at most 100 characters")
+    .min(1, "First name is required")
+    .max(50, "Too long")
     .regex(nameRegex, "Only alphabets and spaces are allowed"),
-  email: z.string().trim().email("Invalid email"),
-  phone_no: z
+  lastName: z
     .string()
-    .min(10, "Phone must be 10-15 digits")
-    .max(15, "Phone must be 10-15 digits")
-    .regex(/^[0-9]+$/, "Digits only"),
-  gender: z.string().refine((val) => GENDER_VALUES.includes(val), {
-    message: "Select gender",
-  }),
-  category: z.string().refine((val) => CATEGORY_VALUES.includes(val), {
-    message: "Select Category",
-  }),
-  admission_date: z.string().refine((v) => {
-    if (!v) return false;
-    const d = new Date(v);
-    if (isNaN(d.getTime())) return false;
-    const today = new Date();
-    return d <= today;
-  }, "Admission date cannot be in future"),
-  address: z.string().trim().min(1, "Address is required").max(300),
+    .trim()
+    .min(1, "Last name is required")
+    .max(50, "Too long")
+    .regex(nameRegex, "Only alphabets and spaces are allowed"),
+  email: z.string().trim().email("Invalid email").or(z.literal("")),
+  phone_no: optionalMobile,
+  gender: z.enum(GENDER_VALUES, { message: "Select gender" }),
+  category: z.string().optional().or(z.literal("")),
+  admission_date: z
+    .string()
+    .optional()
+    .or(z.literal(""))
+    .refine((v) => {
+      if (!v) return true;
+      const d = new Date(v);
+      if (isNaN(d.getTime())) return false;
+      return d <= new Date();
+    }, "Admission date cannot be in future"),
+  classId: z.string().optional().or(z.literal("")),
+  address: z.string().trim().max(300).optional().or(z.literal("")),
   aadhar: z
     .string()
-    .length(12, "Aadhar must be 12 digits")
-    .regex(/^[0-9]{12}$/g, "Aadhar must be numeric"),
-  guardian: guardianSchema,
-  student_documents: z.array(documentSchema),
+    .transform((v) => v.replace(/\D/g, ""))
+    .refine((v) => v === "" || /^[0-9]{12}$/.test(v), {
+      message: "Aadhar must be exactly 12 digits",
+    }),
+  father_name: z.string().trim().max(100).optional().or(z.literal("")),
+  father_mobile: optionalMobile,
+  mother_name: z.string().trim().max(100).optional().or(z.literal("")),
+  mother_mobile: optionalMobile,
+  guardian_name: z.string().trim().max(100).optional().or(z.literal("")),
+  guardian_mobile: optionalMobile,
+  bloodGroup: z.string().trim().max(10).optional().or(z.literal("")),
+  medicalNotes: z.string().trim().max(500).optional().or(z.literal("")),
   class_name: z.string().optional(),
   admission_locked: z.boolean().optional(),
 });
@@ -77,22 +65,24 @@ export const updateStudentSchema = z.object({
 export type UpdateStudentForm = z.infer<typeof updateStudentSchema>;
 
 export const updateStudentDefaultValues: UpdateStudentForm = {
-  name: "",
+  firstName: "",
+  lastName: "",
   email: "",
   phone_no: "",
-  gender: "male",
-  category: "General",
+  gender: "MALE",
+  category: "",
   admission_date: "",
+  classId: "",
   address: "",
   aadhar: "",
-  guardian: {
-    father_name: "",
-    mother_name: "",
-    phone_no: "",
-    email: "",
-    address: "",
-  },
-  student_documents: [],
+  father_name: "",
+  father_mobile: "",
+  mother_name: "",
+  mother_mobile: "",
+  guardian_name: "",
+  guardian_mobile: "",
+  bloodGroup: "",
+  medicalNotes: "",
   class_name: "",
   admission_locked: false,
 };

--- a/src/modules/students/types/admin.ts
+++ b/src/modules/students/types/admin.ts
@@ -24,22 +24,30 @@ export type StudentsQuery = {
   pageSize?: number;
 };
 
+/** GET /admin/students/{id} response */
 export interface StudentDetails {
   id: string;
   name: string;
   email: string;
   studentId: string;
-  phoneNo: string;
+  phoneNo: string | null;
   gender: string | null;
-  category: string | null;
   admissionDate: string | null;
-  aadhaar: string | null;
+  aadhaarNumber: string | null;
   address: string | null;
-  rollNo: string | null;
   fatherName: string | null;
   fatherMobile: string | null;
-  fatherEmail: string | null;
   motherName: string | null;
-  emergencyContact: string | null;
+  motherMobile: string | null;
+  guardianName: string | null;
+  guardianMobile: string | null;
+  bloodGroup: string | null;
+  medicalNotes: string | null;
   dob: string | null;
+  /** Optional class fields when API includes them */
+  classId?: string | null;
+  className?: string | null;
+  category?: string | null;
+  /** @deprecated Prefer aadhaarNumber */
+  aadhaar?: string | null;
 }

--- a/src/modules/students/types/form.ts
+++ b/src/modules/students/types/form.ts
@@ -1,25 +1,21 @@
 import type { StudentDocument } from "@/modules/documents/types";
+import type { StudentDetails } from "./admin";
 
 export type { StudentDocument, UploadingDoc } from "@/modules/documents/types";
 
-export type StudentProfileResponse = {
-  studentId: string;
-  id?: string;
-  name: string;
-  class_id: string;
+/** Alias for GET /admin/students/{id} used by the update dialog loader */
+export type StudentProfileResponse = StudentDetails & {
+  /** Legacy snake_case fallbacks some environments may still return */
+  phone_no?: string;
+  admission_date?: string | null;
+  aadhar?: string;
+  class_id?: string | { id?: string; name?: string; className?: string };
   class_name?: string;
-  email: string;
-  phone_no: string;
-  gender: "male" | "female" | "other";
-  category: "General" | "OBC" | "SC" | "ST" | "EWS";
-  admission_date: string | null;
-  address: string;
-  aadhar: string;
-  guardian: {
-    father_name: string;
+  guardian?: {
+    father_name?: string;
     mother_name?: string | null;
-    phone_no: string;
-    email: string;
+    phone_no?: string;
+    email?: string;
     address?: string | null;
   };
   student_documents?: StudentDocument[];

--- a/src/modules/students/utils/formatters.ts
+++ b/src/modules/students/utils/formatters.ts
@@ -2,6 +2,28 @@ export function cleanDigits(value: string) {
   return value.replace(/\D+/g, "");
 }
 
+/** Normalize a phone for form display: digits only, keep last 10 if longer (e.g. +91…). */
+export function normalizeMobileForForm(value?: string | null): string {
+  const digits = cleanDigits(value ?? "");
+  if (!digits) return "";
+  return digits.length > 10 ? digits.slice(-10) : digits;
+}
+
+/** Display 10 digits as "XXXXX XXXXX" (space between 5-digit groups). */
+export function formatMobileDisplay(value: string): string {
+  const digits = cleanDigits(value).slice(0, 10);
+  if (digits.length <= 5) return digits;
+  return `${digits.slice(0, 5)} ${digits.slice(5)}`;
+}
+
+/** Display 12-digit Aadhaar as "XXXX XXXX XXXX". */
+export function formatAadharDisplay(value: string): string {
+  const digits = cleanDigits(value).slice(0, 12);
+  return digits.replace(/(\d{4})(\d{0,4})(\d{0,4})/, (_, p1, p2, p3) =>
+    [p1, p2, p3].filter(Boolean).join(" "),
+  );
+}
+
 export function toLower(value: string) {
   return value.trim().toLowerCase();
 }
@@ -16,4 +38,29 @@ export function parseLocalDate(value?: string) {
   if (!value) return undefined;
   const [y, m, d] = value.split("-").map(Number);
   return new Date(y, m - 1, d);
+}
+
+/** Split a full name into first + remaining last name parts. */
+export function splitFullName(name: string): {
+  firstName: string;
+  lastName: string;
+} {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { firstName: "", lastName: "" };
+  if (parts.length === 1) return { firstName: parts[0], lastName: "" };
+  return { firstName: parts[0], lastName: parts.slice(1).join(" ") };
+}
+
+/** Normalize gender for API payload (MALE / FEMALE / OTHER). */
+export function formatGenderForApi(gender: string): "MALE" | "FEMALE" | "OTHER" {
+  const value = gender.trim().toUpperCase();
+  if (value === "MALE" || value === "FEMALE" || value === "OTHER") return value;
+  return "MALE";
+}
+
+/** Normalize API gender (MALE / Male / male) to form value (MALE). */
+export function normalizeGenderForForm(
+  gender?: string | null,
+): "MALE" | "FEMALE" | "OTHER" {
+  return formatGenderForApi(gender ?? "");
 }


### PR DESCRIPTION
## Summary
- Align update-student form and types with phase 1 profile fields (guardian mobiles, medical notes, gender enums)
- Add reusable entity documents section on the student profile page

## Test plan
- [ ] Open admin student profile and edit with new guardian/mobile/medical fields
- [ ] Validate mobile formatting and 10-digit checks
- [ ] Upload and delete a student document from the profile page
- [ ] Confirm update API payload matches the backend phase 1 schema


Made with [Cursor](https://cursor.com)