### PR TITLE
Fix admin classes create/edit teacher selection and validation

### DIFF
--- a/src/app/admin/classes/page.tsx
+++ b/src/app/admin/classes/page.tsx
@@ -94,7 +94,11 @@ export default function AdminClassesPage() {
             <CreateNewClass
               isOpen={open}
               onClose={() => setOpen(false)}
-            ></CreateNewClass>
+              onCreated={() => {
+                void load({ page, pageSize });
+                void fetchStats();
+              }}
+            />
             <CreateClassDialog
               open={creatingOpen}
               onClose={() => setCreatingOpen(false)}

--- a/src/modules/classes/api/classes.ts
+++ b/src/modules/classes/api/classes.ts
@@ -268,9 +268,9 @@ export async function fetchClassDashboard(): Promise<ClassDashboardStats | null>
 
 export async function updateClass(
   id: string,
-  payload: { room_no: string; classTeacherId: string },
+  payload: { room_no: string; classTeacherId?: string },
 ): Promise<void> {
-  await API.put(`${ADMIN_API.CLASSES}/${id}`, payload);
+  await API.patch(`${ADMIN_API.CLASSES}/${id}`, payload);
 }
 
 export async function assignTeacherToClass(

--- a/src/modules/classes/components/CreateClassDialog.tsx
+++ b/src/modules/classes/components/CreateClassDialog.tsx
@@ -96,9 +96,16 @@ export default function CreateClassDialog({ open, onClose, onCreated }: Props) {
                   </span>
                   <Input
                     {...form.register("number")}
-                    placeholder="e.g. 5"
+                    placeholder="e.g. 5 (1–12)"
                     inputMode="numeric"
                     className="rounded-l-none"
+                    onInput={(e: React.FormEvent<HTMLInputElement>) => {
+                      const el = e.currentTarget as HTMLInputElement;
+                      el.value = el.value.replace(/\D/g, "").slice(0, 2);
+                      form.setValue("number", el.value, {
+                        shouldValidate: true,
+                      });
+                    }}
                   />
                 </div>
                 <FormMessage>
@@ -114,11 +121,17 @@ export default function CreateClassDialog({ open, onClose, onCreated }: Props) {
                   </span>
                   <Input
                     {...form.register("section")}
-                    placeholder="Optional (A)"
+                    placeholder="Optional (A–E)"
+                    maxLength={1}
                     onInput={(e: React.FormEvent<HTMLInputElement>) => {
                       const el = e.currentTarget as HTMLInputElement;
-                      el.value = el.value.toUpperCase().slice(0, 1);
-                      form.setValue("section", el.value);
+                      el.value = el.value
+                        .toUpperCase()
+                        .replace(/[^A-E]/g, "")
+                        .slice(0, 1);
+                      form.setValue("section", el.value, {
+                        shouldValidate: true,
+                      });
                     }}
                     className="rounded-l-none"
                   />

--- a/src/modules/classes/components/CreateClassForm.tsx
+++ b/src/modules/classes/components/CreateClassForm.tsx
@@ -32,6 +32,17 @@ interface Props {
   classId?: string | null;
 }
 
+function sanitizeClassName(value: string) {
+  return value.replace(/\D/g, "").slice(0, 2);
+}
+
+function sanitizeSection(value: string) {
+  return value
+    .toUpperCase()
+    .replace(/[^A-E]/g, "")
+    .slice(0, 1);
+}
+
 export default function CreateClassForm({ onClose, onCreated }: Props) {
   const { toast } = useToast();
 
@@ -67,9 +78,24 @@ export default function CreateClassForm({ onClose, onCreated }: Props) {
 
   function validate(): boolean {
     const errs: Record<string, string> = {};
+    const classNum = Number(className.trim());
 
-    if (!className.trim()) errs.className = "Class name is required";
-    if (!section.trim()) errs.section = "Section is required";
+    if (!className.trim()) {
+      errs.className = "Class name is required";
+    } else if (
+      !/^\d{1,2}$/.test(className.trim()) ||
+      classNum < 1 ||
+      classNum > 12
+    ) {
+      errs.className = "Class name must be a number from 1 to 12";
+    }
+
+    if (!section.trim()) {
+      errs.section = "Section is required";
+    } else if (!/^[A-E]$/.test(section.trim())) {
+      errs.section = "Section must be a letter from A–E";
+    }
+
     if (!homeRoom.trim()) errs.homeRoom = "Home room is required";
     if (!classTeacherId) errs.classTeacherId = "Class teacher is required";
     if (selectedSubjects.length === 0)
@@ -82,7 +108,12 @@ export default function CreateClassForm({ onClose, onCreated }: Props) {
         errs[`assignment_${a.subjectId}_start`] = "Start time required";
       if (!a.endTime)
         errs[`assignment_${a.subjectId}_end`] = "End time required";
-      if (!a.room) errs[`assignment_${a.subjectId}_room`] = "Room is required";
+      if (a.startTime && a.endTime && a.startTime >= a.endTime) {
+        errs[`assignment_${a.subjectId}_end`] =
+          "End time must be after start time";
+      }
+      if (!a.room?.trim())
+        errs[`assignment_${a.subjectId}_room`] = "Room is required";
     });
 
     setValidationErrors(errs);
@@ -105,9 +136,9 @@ export default function CreateClassForm({ onClose, onCreated }: Props) {
       }));
 
       const payload = {
-        className,
-        section,
-        homeRoom,
+        className: className.trim(),
+        section: section.trim().toUpperCase(),
+        homeRoom: homeRoom.trim(),
         classTeacherId,
         subjects: subjectsPayload,
       };
@@ -115,7 +146,9 @@ export default function CreateClassForm({ onClose, onCreated }: Props) {
       const res = await createClassWithSubjects(payload);
 
       toast({
-        title: (res as { message?: string })?.message ?? "Class created successfully",
+        title:
+          (res as { message?: string })?.message ??
+          "Class created successfully",
         type: "success",
       });
 
@@ -152,8 +185,11 @@ export default function CreateClassForm({ onClose, onCreated }: Props) {
               <FormControl>
                 <Input
                   value={className}
-                  onChange={(e) => setClassName(e.target.value)}
-                  placeholder="Class-10"
+                  onChange={(e) =>
+                    setClassName(sanitizeClassName(e.target.value))
+                  }
+                  placeholder="e.g. 10"
+                  inputMode="numeric"
                 />
               </FormControl>
               <FormMessage>{validationErrors.className}</FormMessage>
@@ -164,8 +200,11 @@ export default function CreateClassForm({ onClose, onCreated }: Props) {
               <FormControl>
                 <Input
                   value={section}
-                  onChange={(e) => setSection(e.target.value)}
-                  placeholder="B"
+                  onChange={(e) =>
+                    setSection(sanitizeSection(e.target.value))
+                  }
+                  placeholder="A–E"
+                  maxLength={1}
                 />
               </FormControl>
               <FormMessage>{validationErrors.section}</FormMessage>
@@ -193,6 +232,7 @@ export default function CreateClassForm({ onClose, onCreated }: Props) {
           <SearchableDropdown
             value={classTeacherId}
             onChange={setClassTeacherId}
+            placeholder="Select class teacher"
           />
 
           {validationErrors.classTeacherId && (
@@ -240,53 +280,119 @@ export default function CreateClassForm({ onClose, onCreated }: Props) {
                       <button
                         type="button"
                         onClick={() => removeSubject(a.subjectId)}
+                        aria-label={`Remove ${subject?.name ?? "subject"}`}
                       >
                         <X size={16} />
                       </button>
+                    </div>
 
-                      <SearchableDropdown
-                        value={a.teacherId ?? null}
-                        subjectId={a.subjectId}
-                        onChange={(id) =>
-                          updateAssignment(a.subjectId, {
-                            teacherId: id,
-                          })
-                        }
-                        fetchTeachers={getTeachers}
-                      />
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+                      <div>
+                        <label className="block text-xs text-slate-500 mb-1">
+                          Teacher *
+                        </label>
+                        <SearchableDropdown
+                          value={a.teacherId ?? null}
+                          subjectId={a.subjectId}
+                          onChange={(id) =>
+                            updateAssignment(a.subjectId, {
+                              teacherId: id,
+                            })
+                          }
+                          fetchTeachers={getTeachers}
+                          placeholder="Select teacher"
+                        />
+                        {validationErrors[
+                          `assignment_${a.subjectId}_teacher`
+                        ] && (
+                          <div className="text-sm text-red-600 mt-1">
+                            {
+                              validationErrors[
+                                `assignment_${a.subjectId}_teacher`
+                              ]
+                            }
+                          </div>
+                        )}
+                      </div>
 
-                      <input
-                        type="time"
-                        value={a.startTime || ""}
-                        onChange={(e) =>
-                          updateAssignment(a.subjectId, {
-                            startTime: e.target.value,
-                          })
-                        }
-                        className="border rounded px-3 py-2"
-                      />
+                      <div>
+                        <label className="block text-xs text-slate-500 mb-1">
+                          Start *
+                        </label>
+                        <input
+                          type="time"
+                          value={a.startTime || ""}
+                          onChange={(e) =>
+                            updateAssignment(a.subjectId, {
+                              startTime: e.target.value,
+                            })
+                          }
+                          className="w-full border rounded px-3 py-2"
+                        />
+                        {validationErrors[
+                          `assignment_${a.subjectId}_start`
+                        ] && (
+                          <div className="text-sm text-red-600 mt-1">
+                            {
+                              validationErrors[
+                                `assignment_${a.subjectId}_start`
+                              ]
+                            }
+                          </div>
+                        )}
+                      </div>
 
-                      <input
-                        type="time"
-                        value={a.endTime || ""}
-                        onChange={(e) =>
-                          updateAssignment(a.subjectId, {
-                            endTime: e.target.value,
-                          })
-                        }
-                        className="border rounded px-3 py-2"
-                      />
+                      <div>
+                        <label className="block text-xs text-slate-500 mb-1">
+                          End *
+                        </label>
+                        <input
+                          type="time"
+                          value={a.endTime || ""}
+                          onChange={(e) =>
+                            updateAssignment(a.subjectId, {
+                              endTime: e.target.value,
+                            })
+                          }
+                          className="w-full border rounded px-3 py-2"
+                        />
+                        {validationErrors[`assignment_${a.subjectId}_end`] && (
+                          <div className="text-sm text-red-600 mt-1">
+                            {
+                              validationErrors[
+                                `assignment_${a.subjectId}_end`
+                              ]
+                            }
+                          </div>
+                        )}
+                      </div>
 
-                      <input
-                        placeholder="Room"
-                        value={a.room || ""}
-                        onChange={(e) =>
-                          updateAssignment(a.subjectId, {
-                            room: e.target.value,
-                          })
-                        }
-                        className="border rounded px-3 py-2"
-                      />
+                      <div>
+                        <label className="block text-xs text-slate-500 mb-1">
+                          Room *
+                        </label>
+                        <input
+                          placeholder="Room"
+                          value={a.room || ""}
+                          onChange={(e) =>
+                            updateAssignment(a.subjectId, {
+                              room: e.target.value,
+                            })
+                          }
+                          className="w-full border rounded px-3 py-2"
+                        />
+                        {validationErrors[
+                          `assignment_${a.subjectId}_room`
+                        ] && (
+                          <div className="text-sm text-red-600 mt-1">
+                            {
+                              validationErrors[
+                                `assignment_${a.subjectId}_room`
+                              ]
+                            }
+                          </div>
+                        )}
+                      </div>
                     </div>
                   </div>
                 );

--- a/src/modules/classes/components/CreateNewClass.tsx
+++ b/src/modules/classes/components/CreateNewClass.tsx
@@ -6,6 +6,7 @@ import CreateClassForm from "./CreateClassForm";
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onCreated?: () => void;
   classId?: string | null;
   title?: string;
   children?: ReactNode;
@@ -14,6 +15,7 @@ interface ModalProps {
 export default function CreateNewClass({
   isOpen,
   onClose,
+  onCreated,
   classId = null,
   title = "Create New Class",
 }: ModalProps) {
@@ -50,7 +52,11 @@ export default function CreateNewClass({
           </div>
         </div>
 
-        <CreateClassForm classId={classId} onClose={onClose} />
+        <CreateClassForm
+          classId={classId}
+          onClose={onClose}
+          onCreated={onCreated}
+        />
       </div>
     </div>
   );

--- a/src/modules/classes/components/EditClassDialog.tsx
+++ b/src/modules/classes/components/EditClassDialog.tsx
@@ -5,10 +5,14 @@ import { isAxiosError } from "axios";
 import { Lock, Plus } from "lucide-react";
 import Button from "@/components/ui/Button";
 import Card from "@/components/ui/Card";
-import { FormField, FormLabel, FormControl, FormMessage } from "@/components/ui/Form";
+import {
+  FormField,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/Form";
 import { Input } from "@/components/ui/Input";
 import { useToast } from "@/components/ui/use-toast";
-import { SearchableDropdown, getTeachers } from "@/modules/teachers";
 import { fetchClassById, updateClass } from "@/modules/classes/api/classes";
 
 type Props = {
@@ -30,7 +34,6 @@ export default function EditClassDialog({
   const [className, setClassName] = useState("");
   const [section, setSection] = useState("");
   const [roomNo, setRoomNo] = useState("");
-  const [classTeacherId, setClassTeacherId] = useState<string | null>(null);
   const [classTeacherName, setClassTeacherName] = useState("");
   const [errors, setErrors] = useState<Record<string, string>>({});
 
@@ -46,7 +49,6 @@ export default function EditClassDialog({
         setSection(data.section);
         setRoomNo(data.homeRoom);
         setClassTeacherName(data.classTeacherName);
-        setClassTeacherId(null);
       })
       .catch(() => {
         if (!mounted) return;
@@ -65,8 +67,6 @@ export default function EditClassDialog({
   function validate() {
     const errs: Record<string, string> = {};
     if (!roomNo.trim()) errs.roomNo = "Room number is required";
-    if (!classTeacherId && !classTeacherName)
-      errs.classTeacherId = "Class teacher is required";
     setErrors(errs);
     return Object.keys(errs).length === 0;
   }
@@ -75,24 +75,10 @@ export default function EditClassDialog({
     e.preventDefault();
     if (!classId || !validate()) return;
 
-    let teacherId = classTeacherId;
-    if (!teacherId && classTeacherName) {
-      const teachers = await getTeachers(classTeacherName);
-      teacherId = teachers.find((t) => t.name === classTeacherName)?.id ?? null;
-    }
-    if (!teacherId) {
-      setErrors((prev) => ({
-        ...prev,
-        classTeacherId: "Class teacher is required",
-      }));
-      return;
-    }
-
     setLoading(true);
     try {
       await updateClass(classId, {
         room_no: roomNo.trim(),
-        classTeacherId: teacherId,
       });
       toast({ title: "Class updated successfully", type: "success" });
       onUpdated?.();
@@ -176,18 +162,13 @@ export default function EditClassDialog({
                 <FormField>
                   <FormLabel>Class Teacher</FormLabel>
                   <FormControl>
-                    <SearchableDropdown
-                      value={classTeacherId}
-                      onChange={setClassTeacherId}
-                      selectedLabel={classTeacherName}
-                      fetchTeachers={getTeachers}
-                      placeholder="Select class teacher"
-                    />
+                    <div className="flex items-center justify-between w-full rounded-md border border-[#D7E3FC] bg-[#F5F9FF] px-3 py-2 text-[14px] text-[#64748B]">
+                      <span>{classTeacherName || "Not Assigned"}</span>
+                      <Lock size={14} className="text-[#94A3B8]" />
+                    </div>
                   </FormControl>
-                  <FormMessage>{errors.classTeacherId}</FormMessage>
                   <p className="text-[12px] text-[#737373] mt-1">
-                    The teacher will be responsible for attendance and grading
-                    for this class.
+                    Class teacher cannot be changed from this screen for now.
                   </p>
                 </FormField>
               </div>

--- a/src/modules/classes/schemas/createClassSchema.ts
+++ b/src/modules/classes/schemas/createClassSchema.ts
@@ -5,13 +5,17 @@ export const createClassSchema = z
     number: z
       .string()
       .min(1, "Class number is required")
-      .regex(/^\d{1,2}$/, "Class number must be 1 or 2 digits"),
+      .regex(/^\d{1,2}$/, "Class number must be digits only")
+      .refine((v) => {
+        const n = Number(v);
+        return n >= 1 && n <= 12;
+      }, "Class number must be between 1 and 12"),
     section: z
       .string()
       .optional()
       .transform((v) => (v ? v.trim().toUpperCase() : undefined))
-      .refine((v) => v === undefined || /^[A-Z]$/.test(v), {
-        message: "Section must be a single letter A–Z",
+      .refine((v) => v === undefined || /^[A-E]$/.test(v), {
+        message: "Section must be a letter from A–E",
       }),
   })
   .required();

--- a/src/modules/teachers/api/adminTeachers.ts
+++ b/src/modules/teachers/api/adminTeachers.ts
@@ -22,7 +22,12 @@ export async function fetchTeachers(
   const params: Record<string, string | number> = {};
   if (query.search) params.search = query.search;
   if (query.email) params.email = query.email;
-  if (query.subjectId) params.subjectId = query.subjectId;
+  const subjectIds = [
+    ...(query.subjectIds ?? []),
+    ...(query.subjectId ? [query.subjectId] : []),
+  ].filter(Boolean);
+  // Backend accepts repeated or comma-separated subjectIds (specialty filter).
+  if (subjectIds.length) params.subjectIds = subjectIds.join(",");
   if (query.classId) params.classId = query.classId;
   if (query.page) params.page = query.page;
   if (query.pageSize) {
@@ -159,6 +164,8 @@ export async function fetchTeachers(
       }
     }
 
+    const userId = String(itObj.userId ?? user.id ?? "") || undefined;
+
     return {
       id: (itObj.id ?? user.id ?? "") as string,
       name,
@@ -172,6 +179,7 @@ export async function fetchTeachers(
         : null,
       classTeacher,
       invitedAt: (itObj.invitedAt ?? null) as string | null,
+      user: userId ? { id: userId, fullName: name, email, phone } : null,
     } as Teacher;
   });
 

--- a/src/modules/teachers/api/teacherService.ts
+++ b/src/modules/teachers/api/teacherService.ts
@@ -25,28 +25,45 @@ function normalizeTeacher(it: {
   id?: string;
   name?: string;
   subjects?: string[] | null;
+  subjectsSpeciality?: string[] | null;
   user?: { id?: string } | null;
+  userId?: string | null;
+  user_id?: string | null;
 } | null): TeacherOption {
   if (!it) return { id: "", name: "" };
+  const specialty = Array.isArray(it.subjectsSpeciality)
+    ? it.subjectsSpeciality
+    : Array.isArray(it.subjects)
+      ? it.subjects
+      : undefined;
+  const userId = it.user_id ?? it.userId ?? it.user?.id;
   return {
     id: String(it.id ?? ""),
     name: String(it.name ?? ""),
-    subjects: Array.isArray(it.subjects) ? it.subjects : undefined,
-    user_id: it.user?.id,
+    subjects: specialty?.filter(Boolean) as string[] | undefined,
+    user_id: userId ? String(userId) : undefined,
   };
 }
 
 export async function getTeachers(search = "", subjectId?: string | null) {
   const res = await adminFetchTeachers({
     search,
-    subjectId: subjectId ?? undefined,
+    subjectIds: subjectId ? [subjectId] : undefined,
+    page: 1,
+    pageSize: 100,
   });
   return (res.teachers ?? []).map(normalizeTeacher);
 }
 
 export async function getNotClassTeachers(search = "") {
   const res = await API.get(ADMIN_API.TEACHERS, {
-    params: { search, availableForClassTeacher: true },
+    params: {
+      search,
+      availableForClassTeacher: true,
+      page: 1,
+      pageSize: 100,
+      limit: 100,
+    },
   });
   const data = res?.data ?? res;
   const items = Array.isArray(data)
@@ -57,14 +74,19 @@ export async function getNotClassTeachers(search = "") {
       string,
       unknown
     >;
+    const nestedUser =
+      o.user && typeof o.user === "object"
+        ? (o.user as { id?: string })
+        : null;
     return normalizeTeacher({
       id: String(o.id ?? o._id ?? ""),
       name: String(o.fullName ?? o.name ?? o.email ?? ""),
       subjects: Array.isArray(o.subjects) ? (o.subjects as string[]) : null,
-      user:
-        o.user && typeof o.user === "object"
-          ? (o.user as { id?: string })
-          : null,
+      subjectsSpeciality: Array.isArray(o.subjectsSpeciality)
+        ? (o.subjectsSpeciality as string[])
+        : null,
+      userId: o.userId ? String(o.userId) : undefined,
+      user: nestedUser,
     });
   });
 }

--- a/src/modules/teachers/components/SearchableDropdown.tsx
+++ b/src/modules/teachers/components/SearchableDropdown.tsx
@@ -12,10 +12,25 @@ interface Props {
   placeholder?: string;
   selectedLabel?: string | null;
   subjectId?: string | null;
+  /** Which teacher id to emit/match. Create class uses user_id; update class uses profile id. */
+  idKey?: "user_id" | "id";
   fetchTeachers?: (
     search: string,
     subjectId?: string | null,
   ) => Promise<Teacher[]>;
+}
+
+function teacherSelectId(
+  t: Teacher,
+  idKey: "user_id" | "id",
+): string | null {
+  if (idKey === "id") return t.id || null;
+  return t.user_id || null;
+}
+
+function teacherLabel(t: Teacher): string {
+  const specialty = (t.subjects ?? []).filter(Boolean).join(", ");
+  return specialty ? `${t.name} — ${specialty}` : t.name;
 }
 
 export default function SearchableDropdown({
@@ -25,6 +40,7 @@ export default function SearchableDropdown({
   selectedLabel,
   fetchTeachers,
   subjectId,
+  idKey = "user_id",
 }: Props) {
   const [open, setOpen] = useState(false);
   const [options, setOptions] = useState<Teacher[]>([]);
@@ -37,6 +53,11 @@ export default function SearchableDropdown({
   useEffect(() => {
     fetchFnRef.current = fetchTeachers ?? getNotClassTeachers;
   }, [fetchTeachers]);
+
+  useEffect(() => {
+    setFetched(false);
+    setOptions([]);
+  }, [subjectId]);
 
   useEffect(() => {
     function onDoc(e: MouseEvent) {
@@ -65,7 +86,8 @@ export default function SearchableDropdown({
         setFetched(true);
         if (!value && selectedLabel) {
           const match = list.find((t) => t.name === selectedLabel);
-          if (match) onChange(match.user_id ?? null);
+          const id = match ? teacherSelectId(match, idKey) : null;
+          if (id) onChange(id);
         }
       })
       .catch(() => {
@@ -79,14 +101,19 @@ export default function SearchableDropdown({
     return () => {
       mounted = false;
     };
-  }, [open, fetched, subjectId, value, selectedLabel, onChange]);
+  }, [open, fetched, subjectId, value, selectedLabel, onChange, idKey]);
 
-  const selected = options.find((o) => o.user_id === value) ?? null;
-  const displayName = selected?.name ?? selectedLabel ?? placeholder;
+  const selected =
+    options.find((o) => teacherSelectId(o, idKey) === value) ?? null;
+  const displayName = selected
+    ? teacherLabel(selected)
+    : (selectedLabel ?? placeholder);
 
-  const filtered = options.filter(
-    (o) => !search || o.name.toLowerCase().includes(search.toLowerCase()),
-  );
+  const filtered = options.filter((o) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return teacherLabel(o).toLowerCase().includes(q);
+  });
 
   return (
     <div ref={ref} className="relative">
@@ -97,7 +124,7 @@ export default function SearchableDropdown({
           setOpen((s) => !s);
         }}
       >
-        <div>{displayName}</div>
+        <div className="truncate">{displayName}</div>
         <div>▾</div>
       </div>
       {open && (
@@ -116,19 +143,22 @@ export default function SearchableDropdown({
             <div className="p-2 text-sm text-slate-500">No teachers found</div>
           )}
           {!loading &&
-            filtered.map((opt) => (
-              <div
-                key={opt.id}
-                className="p-2 hover:bg-slate-50 cursor-pointer"
-                onClick={() => {
-                  onChange(opt.user_id ?? null);
-                  setOpen(false);
-                  setSearch("");
-                }}
-              >
-                {opt.name}
-              </div>
-            ))}
+            filtered.map((opt) => {
+              const id = teacherSelectId(opt, idKey);
+              return (
+                <div
+                  key={opt.id || id || opt.name}
+                  className="p-2 hover:bg-slate-50 cursor-pointer"
+                  onClick={() => {
+                    onChange(id);
+                    setOpen(false);
+                    setSearch("");
+                  }}
+                >
+                  {teacherLabel(opt)}
+                </div>
+              );
+            })}
         </div>
       )}
     </div>

--- a/src/modules/teachers/types/admin.ts
+++ b/src/modules/teachers/types/admin.ts
@@ -37,7 +37,10 @@ export type TeachersResponse = {
 export type TeachersQuery = {
   search?: string;
   email?: string;
+  /** Filter by subject specialty (single id; sent as subjectIds to API). */
   subjectId?: string;
+  /** Filter by subject specialty IDs (match any). */
+  subjectIds?: string[];
   classId?: string;
   page?: number;
   pageSize?: number;


### PR DESCRIPTION
## Summary
- Enforce class name as digits 1–12 and section as A–E in create class flows
- Fix teacher dropdown selection (`userId` mapping) and show subject specialties
- Filter Assignment Schedule teachers by subject specialty (`subjectIds`)
- Lock class teacher editing in Edit Class for now; room number remains editable

## Test plan
- [ ] Create class: class name rejects non-digits and values outside 1–12
- [ ] Create class: section only accepts A–E
- [ ] Class Teacher dropdown lists available teachers with specialty and selection works
- [ ] Assignment Schedule teacher list is filtered by selected subject specialty
- [ ] Create class succeeds and refreshes classes list/stats
- [ ] Edit class: class teacher is locked/read-only; room number can still be saved

Made with [Cursor](https://cursor.com)