### PR TITLE
Add examination management UI

### DIFF
--- a/src/app/admin/exams/[examId]/class-report/page.tsx
+++ b/src/app/admin/exams/[examId]/class-report/page.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { use } from "react";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { StatCardsGridSkeleton, DataTableSkeleton } from "@/components/skeletons";
+import StatCard from "@/components/admin/StatCard";
+import {
+  ExamSubnav,
+  formatClassLabel,
+  formatPercent,
+  useClassReport,
+  useExam,
+} from "@/modules/exams";
+import { Users, Percent, CheckCircle2, XCircle } from "lucide-react";
+
+export default function ExamClassReportPage({
+  params,
+}: {
+  params: Promise<{ examId: string }>;
+}) {
+  const { examId } = use(params);
+  const examQuery = useExam(examId);
+  const reportQuery = useClassReport(examId);
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-2">
+        <h1 className="text-[24px] font-[600] text-[#021034]">Class report</h1>
+        <p className="mt-1 text-[14px] text-[#737373]">
+          {examQuery.data?.name ?? "…"} ·{" "}
+          {formatClassLabel(
+            examQuery.data?.className,
+            examQuery.data?.classSection,
+          )}
+        </p>
+      </div>
+
+      <ExamSubnav examId={examId} />
+
+      {reportQuery.isLoading ? (
+        <>
+          <StatCardsGridSkeleton count={4} />
+          <div className="mt-4">
+            <DataTableSkeleton
+              rows={5}
+              columns={[
+                { headerWidth: "w-32", cellWidth: "w-40" },
+                { headerWidth: "w-20", cellWidth: "w-24" },
+                { headerWidth: "w-20", cellWidth: "w-24" },
+              ]}
+            />
+          </div>
+        </>
+      ) : reportQuery.error ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-slate-700">Failed to load class report.</p>
+            <Button variant="dark" onClick={() => void reportQuery.refetch()}>
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : (
+        <>
+          <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <StatCard
+              label="Students"
+              value={String(reportQuery.data?.totalStudents ?? 0)}
+              icon={Users}
+              className="bg-white border-[#BFDBFE]"
+              iconBgColor="bg-[#BFDBFE]"
+              progressLabel=" "
+            />
+            <StatCard
+              label="Class average"
+              value={formatPercent(
+                reportQuery.data?.classAveragePercentage ?? 0,
+              )}
+              icon={Percent}
+              className="bg-white border-[#BFDBFE]"
+              iconBgColor="bg-[#BFDBFE]"
+              progressLabel=" "
+            />
+            <StatCard
+              label="Passed"
+              value={String(reportQuery.data?.passCount ?? 0)}
+              icon={CheckCircle2}
+              className="bg-white border-[#BFDBFE]"
+              iconBgColor="bg-[#BFDBFE]"
+              progressLabel=" "
+            />
+            <StatCard
+              label="Failed"
+              value={String(reportQuery.data?.failCount ?? 0)}
+              icon={XCircle}
+              className="bg-white border-[#BFDBFE]"
+              iconBgColor="bg-[#BFDBFE]"
+              progressLabel=" "
+            />
+          </section>
+
+          <Card className="mt-6">
+            <h2 className="mb-3 text-base font-semibold text-[#021034]">
+              Subject-wise performance
+            </h2>
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="text-left text-slate-500">
+                    <th className="py-2 pr-3">Subject</th>
+                    <th className="py-2 pr-3">Avg marks</th>
+                    <th className="py-2 pr-3">Avg %</th>
+                    <th className="py-2 pr-3">Pass</th>
+                    <th className="py-2 pr-3">Fail</th>
+                    <th className="py-2 pr-3">Absent</th>
+                    <th className="py-2 pr-3">High</th>
+                    <th className="py-2">Low</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(reportQuery.data?.subjects ?? []).map((s) => (
+                    <tr key={s.subjectId} className="border-t border-slate-100">
+                      <td className="py-3 pr-3 font-medium text-[#021034]">
+                        {s.subjectName}
+                      </td>
+                      <td className="py-3 pr-3">{s.averageMarks}</td>
+                      <td className="py-3 pr-3">
+                        {formatPercent(s.averagePercentage)}
+                      </td>
+                      <td className="py-3 pr-3">{s.passCount}</td>
+                      <td className="py-3 pr-3">{s.failCount}</td>
+                      <td className="py-3 pr-3">{s.absentCount}</td>
+                      <td className="py-3 pr-3">{s.highestMarks}</td>
+                      <td className="py-3">{s.lowestMarks}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/exams/[examId]/marks/page.tsx
+++ b/src/app/admin/exams/[examId]/marks/page.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { use, useEffect, useMemo, useState } from "react";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { DataTableSkeleton } from "@/components/skeletons";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  ExamSubnav,
+  useExam,
+  useExamMarks,
+  useExamMutations,
+  formatClassLabel,
+  type UpsertMarkItem,
+} from "@/modules/exams";
+
+type CellState = {
+  marksObtained: string;
+  isAbsent: boolean;
+};
+
+export default function ExamMarksPage({
+  params,
+}: {
+  params: Promise<{ examId: string }>;
+}) {
+  const { examId } = use(params);
+  const { toast } = useToast();
+  const examQuery = useExam(examId);
+  const marksQuery = useExamMarks(examId);
+  const mutations = useExamMutations();
+  const [cells, setCells] = useState<Record<string, CellState>>({});
+
+  const keyOf = (scheduleId: string, studentUserId: string) =>
+    `${scheduleId}:${studentUserId}`;
+
+  useEffect(() => {
+    if (!marksQuery.data) return;
+    const next: Record<string, CellState> = {};
+    for (const student of marksQuery.data.students) {
+      for (const schedule of marksQuery.data.schedules) {
+        const existing = marksQuery.data.marks.find(
+          (m) =>
+            m.scheduleId === schedule.id &&
+            m.studentUserId === student.studentUserId,
+        );
+        next[keyOf(schedule.id, student.studentUserId)] = {
+          marksObtained:
+            existing?.marksObtained === null ||
+            existing?.marksObtained === undefined
+              ? ""
+              : String(existing.marksObtained),
+          isAbsent: existing?.isAbsent ?? false,
+        };
+      }
+    }
+    setCells(next);
+  }, [marksQuery.data]);
+
+  const dirtyItems = useMemo(() => {
+    const items: UpsertMarkItem[] = [];
+    for (const [key, cell] of Object.entries(cells)) {
+      const [scheduleId, studentUserId] = key.split(":");
+      if (!scheduleId || !studentUserId) continue;
+      if (cell.isAbsent) {
+        items.push({ scheduleId, studentUserId, isAbsent: true });
+      } else if (cell.marksObtained !== "") {
+        items.push({
+          scheduleId,
+          studentUserId,
+          isAbsent: false,
+          marksObtained: Number(cell.marksObtained),
+        });
+      }
+    }
+    return items;
+  }, [cells]);
+
+  const handleSave = async () => {
+    try {
+      await mutations.upsertMarks.mutateAsync({
+        examId,
+        marks: dirtyItems,
+      });
+      toast({ title: "Marks saved", type: "success" });
+    } catch (err: unknown) {
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ?? "Failed to save marks";
+      toast({ title: String(msg), type: "error" });
+    }
+  };
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-[24px] font-[600] text-[#021034]">Marks entry</h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            {examQuery.data?.name ?? "…"} ·{" "}
+            {formatClassLabel(
+              examQuery.data?.className,
+              examQuery.data?.classSection,
+            )}
+          </p>
+        </div>
+        <Button
+          variant="dark"
+          onClick={() => void handleSave()}
+          disabled={mutations.upsertMarks.isPending || dirtyItems.length === 0}
+        >
+          {mutations.upsertMarks.isPending ? "Saving…" : "Save marks"}
+        </Button>
+      </div>
+
+      <ExamSubnav examId={examId} />
+
+      {marksQuery.isLoading ? (
+        <DataTableSkeleton
+          rows={8}
+          columns={[
+            { headerWidth: "w-40", cellWidth: "w-48" },
+            { headerWidth: "w-24", cellWidth: "w-28" },
+            { headerWidth: "w-24", cellWidth: "w-28" },
+          ]}
+        />
+      ) : marksQuery.error ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-slate-700">Failed to load marks grid.</p>
+            <Button variant="dark" onClick={() => void marksQuery.refetch()}>
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : (marksQuery.data?.schedules.length ?? 0) === 0 ? (
+        <Card>
+          <p className="text-sm text-slate-600">
+            Add subject schedules before entering marks.
+          </p>
+        </Card>
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-slate-500">
+                  <th className="sticky left-0 bg-white py-2 pr-3">Student</th>
+                  {marksQuery.data!.schedules.map((s) => (
+                    <th key={s.id} className="min-w-[140px] py-2 pr-3">
+                      {s.subjectName}
+                      <div className="text-xs font-normal">
+                        /{s.maxMarks}
+                      </div>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {marksQuery.data!.students.map((student) => (
+                  <tr
+                    key={student.studentUserId}
+                    className="border-t border-slate-100"
+                  >
+                    <td className="sticky left-0 bg-white py-2 pr-3 font-medium text-[#021034]">
+                      {student.studentName}
+                      {student.studentCode ? (
+                        <div className="text-xs text-slate-500">
+                          {student.studentCode}
+                        </div>
+                      ) : null}
+                    </td>
+                    {marksQuery.data!.schedules.map((schedule) => {
+                      const key = keyOf(schedule.id, student.studentUserId);
+                      const cell = cells[key] ?? {
+                        marksObtained: "",
+                        isAbsent: false,
+                      };
+                      return (
+                        <td key={schedule.id} className="py-2 pr-3 align-top">
+                          <div className="flex flex-col gap-1">
+                            <input
+                              type="number"
+                              className="w-24 rounded border border-slate-200 px-2 py-1 text-sm disabled:bg-slate-50"
+                              disabled={cell.isAbsent}
+                              value={cell.marksObtained}
+                              min={0}
+                              max={schedule.maxMarks}
+                              onChange={(e) =>
+                                setCells((prev) => ({
+                                  ...prev,
+                                  [key]: {
+                                    ...cell,
+                                    marksObtained: e.target.value,
+                                  },
+                                }))
+                              }
+                            />
+                            <label className="flex items-center gap-1 text-xs text-slate-500">
+                              <input
+                                type="checkbox"
+                                checked={cell.isAbsent}
+                                onChange={(e) =>
+                                  setCells((prev) => ({
+                                    ...prev,
+                                    [key]: {
+                                      marksObtained: "",
+                                      isAbsent: e.target.checked,
+                                    },
+                                  }))
+                                }
+                              />
+                              Absent
+                            </label>
+                          </div>
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/exams/[examId]/report-cards/page.tsx
+++ b/src/app/admin/exams/[examId]/report-cards/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { use, useState } from "react";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { DataTableSkeleton } from "@/components/skeletons";
+import {
+  ExamSubnav,
+  formatClassLabel,
+  formatPercent,
+  useExam,
+  useExamMarks,
+  useExamResults,
+  useReportCard,
+} from "@/modules/exams";
+
+export default function ExamReportCardsPage({
+  params,
+}: {
+  params: Promise<{ examId: string }>;
+}) {
+  const { examId } = use(params);
+  const [selectedStudentId, setSelectedStudentId] = useState("");
+  const examQuery = useExam(examId);
+  const resultsQuery = useExamResults(examId, { page: 1, limit: 100 });
+  const marksQuery = useExamMarks(examId);
+  const reportQuery = useReportCard(examId, selectedStudentId);
+
+  const students =
+    (resultsQuery.data?.data ?? []).length > 0
+      ? (resultsQuery.data?.data ?? []).map((r) => ({
+          id: r.studentUserId,
+          name: r.studentName ?? "",
+          code: r.studentCode,
+        }))
+      : (marksQuery.data?.students ?? []).map((s) => ({
+          id: s.studentUserId,
+          name: s.studentName,
+          code: s.studentCode,
+        }));
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-2">
+        <h1 className="text-[24px] font-[600] text-[#021034]">Report cards</h1>
+        <p className="mt-1 text-[14px] text-[#737373]">
+          {examQuery.data?.name ?? "…"} ·{" "}
+          {formatClassLabel(
+            examQuery.data?.className,
+            examQuery.data?.classSection,
+          )}
+        </p>
+      </div>
+
+      <ExamSubnav examId={examId} />
+
+      <div className="mb-4 max-w-md">
+        <label className="mb-1 block text-sm text-slate-600">Student</label>
+        <select
+          className="w-full rounded border border-slate-200 bg-white px-3 py-2 text-sm"
+          value={selectedStudentId}
+          onChange={(e) => setSelectedStudentId(e.target.value)}
+        >
+          <option value="">Select student</option>
+          {students.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+              {s.code ? ` (${s.code})` : ""}
+            </option>
+          ))}
+        </select>
+        {students.length === 0 ? (
+          <p className="mt-2 text-xs text-slate-500">
+            No students available for this exam yet.
+          </p>
+        ) : null}
+      </div>
+
+      {!selectedStudentId ? (
+        <Card>
+          <p className="text-sm text-slate-600">
+            Select a student to view their report card.
+          </p>
+        </Card>
+      ) : reportQuery.isLoading ? (
+        <DataTableSkeleton
+          rows={6}
+          columns={[
+            { headerWidth: "w-32", cellWidth: "w-40" },
+            { headerWidth: "w-20", cellWidth: "w-24" },
+            { headerWidth: "w-16", cellWidth: "w-20" },
+          ]}
+        />
+      ) : reportQuery.error ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-slate-700">Failed to load report card.</p>
+            <Button variant="dark" onClick={() => void reportQuery.refetch()}>
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : (
+        <Card>
+          <div className="mb-4 border-b border-slate-100 pb-4">
+            <h2 className="text-lg font-semibold text-[#021034]">
+              {reportQuery.data?.studentName}
+            </h2>
+            <p className="text-sm text-slate-500">
+              {reportQuery.data?.studentCode ?? ""} ·{" "}
+              {reportQuery.data?.exam.name}
+            </p>
+            {reportQuery.data?.result ? (
+              <p className="mt-2 text-sm">
+                Overall: {reportQuery.data.result.totalObtainedMarks}/
+                {reportQuery.data.result.totalMaxMarks} (
+                {formatPercent(reportQuery.data.result.percentage)}) · Grade{" "}
+                {reportQuery.data.result.grade ?? "—"} · Rank{" "}
+                {reportQuery.data.result.rank ?? "—"} ·{" "}
+                <span
+                  className={
+                    reportQuery.data.result.isPassed
+                      ? "text-green-700"
+                      : "text-red-700"
+                  }
+                >
+                  {reportQuery.data.result.isPassed ? "Pass" : "Fail"}
+                </span>
+              </p>
+            ) : null}
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-slate-500">
+                  <th className="py-2 pr-3">Subject</th>
+                  <th className="py-2 pr-3">Marks</th>
+                  <th className="py-2 pr-3">Grade</th>
+                  <th className="py-2">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {reportQuery.data!.subjects.map((s) => (
+                  <tr key={s.subjectId} className="border-t border-slate-100">
+                    <td className="py-3 pr-3 font-medium text-[#021034]">
+                      {s.subjectName}
+                    </td>
+                    <td className="py-3 pr-3">
+                      {s.isAbsent
+                        ? "Absent"
+                        : `${s.marksObtained ?? "—"}/${s.maxMarks}`}
+                    </td>
+                    <td className="py-3 pr-3">{s.grade ?? "—"}</td>
+                    <td className="py-3">
+                      {s.isAbsent ? (
+                        <span className="text-amber-700">Absent</span>
+                      ) : s.isPassed ? (
+                        <span className="text-green-700">Pass</span>
+                      ) : (
+                        <span className="text-red-700">Fail</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/exams/[examId]/results/page.tsx
+++ b/src/app/admin/exams/[examId]/results/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { use, useState } from "react";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { DataTableSkeleton } from "@/components/skeletons";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  ExamSubnav,
+  formatPercent,
+  useExam,
+  useExamMutations,
+  useExamResults,
+  formatClassLabel,
+} from "@/modules/exams";
+
+export default function ExamResultsPage({
+  params,
+}: {
+  params: Promise<{ examId: string }>;
+}) {
+  const { examId } = use(params);
+  const { toast } = useToast();
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const examQuery = useExam(examId);
+  const resultsQuery = useExamResults(examId, {
+    page,
+    limit: 10,
+    search: search || undefined,
+  });
+  const mutations = useExamMutations();
+  const totalPages = Math.max(1, Math.ceil((resultsQuery.data?.total ?? 0) / 10));
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-[24px] font-[600] text-[#021034]">Results</h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            {examQuery.data?.name ?? "…"} ·{" "}
+            {formatClassLabel(
+              examQuery.data?.className,
+              examQuery.data?.classSection,
+            )}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="ghost"
+            disabled={mutations.generateResults.isPending}
+            onClick={() =>
+              void mutations.generateResults
+                .mutateAsync(examId)
+                .then(() =>
+                  toast({ title: "Results generated", type: "success" }),
+                )
+                .catch((err: unknown) => {
+                  const msg =
+                    (err as { response?: { data?: { message?: string } } })
+                      ?.response?.data?.message ?? "Generate failed";
+                  toast({ title: String(msg), type: "error" });
+                })
+            }
+          >
+            Generate
+          </Button>
+          <Button
+            variant="dark"
+            disabled={mutations.publishResults.isPending}
+            onClick={() =>
+              void mutations.publishResults
+                .mutateAsync(examId)
+                .then(() =>
+                  toast({ title: "Results published", type: "success" }),
+                )
+                .catch((err: unknown) => {
+                  const msg =
+                    (err as { response?: { data?: { message?: string } } })
+                      ?.response?.data?.message ?? "Publish failed";
+                  toast({ title: String(msg), type: "error" });
+                })
+            }
+          >
+            Publish
+          </Button>
+        </div>
+      </div>
+
+      <ExamSubnav examId={examId} />
+
+      <div className="mb-4">
+        <input
+          className="w-full max-w-sm rounded border border-slate-200 bg-white px-3 py-2 text-sm"
+          placeholder="Search students"
+          value={search}
+          onChange={(e) => {
+            setPage(1);
+            setSearch(e.target.value);
+          }}
+        />
+      </div>
+
+      {resultsQuery.isLoading ? (
+        <DataTableSkeleton
+          rows={8}
+          columns={[
+            { headerWidth: "w-10", cellWidth: "w-12" },
+            { headerWidth: "w-40", cellWidth: "w-48" },
+            { headerWidth: "w-20", cellWidth: "w-24" },
+            { headerWidth: "w-20", cellWidth: "w-24" },
+            { headerWidth: "w-16", cellWidth: "w-20" },
+          ]}
+        />
+      ) : resultsQuery.error ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-slate-700">Failed to load results.</p>
+            <Button variant="dark" onClick={() => void resultsQuery.refetch()}>
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-slate-500">
+                  <th className="py-2 pr-3">Rank</th>
+                  <th className="py-2 pr-3">Student</th>
+                  <th className="py-2 pr-3">Obtained</th>
+                  <th className="py-2 pr-3">%</th>
+                  <th className="py-2 pr-3">Grade</th>
+                  <th className="py-2">Result</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(resultsQuery.data?.data ?? []).length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="py-8 text-center text-slate-500">
+                      No results yet. Generate after marks entry.
+                    </td>
+                  </tr>
+                ) : (
+                  resultsQuery.data!.data.map((r) => (
+                    <tr key={r.id} className="border-t border-slate-100">
+                      <td className="py-3 pr-3">{r.rank ?? "—"}</td>
+                      <td className="py-3 pr-3 font-medium text-[#021034]">
+                        {r.studentName}
+                      </td>
+                      <td className="py-3 pr-3">
+                        {r.totalObtainedMarks}/{r.totalMaxMarks}
+                      </td>
+                      <td className="py-3 pr-3">
+                        {formatPercent(r.percentage)}
+                      </td>
+                      <td className="py-3 pr-3">{r.grade ?? "—"}</td>
+                      <td className="py-3">
+                        <span
+                          className={`rounded px-2 py-0.5 text-xs font-medium ${
+                            r.isPassed
+                              ? "bg-green-50 text-green-700"
+                              : "bg-red-50 text-red-700"
+                          }`}
+                        >
+                          {r.isPassed ? "Pass" : "Fail"}
+                        </span>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+          <div className="mt-4 flex items-center justify-between">
+            <Button
+              variant="ghost"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+            >
+              Previous
+            </Button>
+            <span className="text-sm text-slate-500">
+              Page {page} of {totalPages}
+            </span>
+            <Button
+              variant="ghost"
+              disabled={page >= totalPages}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/exams/[examId]/schedule/page.tsx
+++ b/src/app/admin/exams/[examId]/schedule/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { use } from "react";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { DataTableSkeleton } from "@/components/skeletons";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  ExamSubnav,
+  ScheduleDialog,
+  useExam,
+  useExamMutations,
+  useExamSchedules,
+  formatClassLabel,
+} from "@/modules/exams";
+import type { CreateScheduleValues } from "@/modules/exams";
+import { useState } from "react";
+
+export default function ExamSchedulePage({
+  params,
+}: {
+  params: Promise<{ examId: string }>;
+}) {
+  const { examId } = use(params);
+  const { toast } = useToast();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const examQuery = useExam(examId);
+  const schedulesQuery = useExamSchedules(examId);
+  const mutations = useExamMutations();
+
+  const handleCreate = async (values: CreateScheduleValues) => {
+    await mutations.createSchedule.mutateAsync({
+      examId,
+      payload: {
+        subjectId: values.subjectId,
+        examDate: values.examDate,
+        startTime: values.startTime,
+        endTime: values.endTime,
+        maxMarks: Number(values.maxMarks),
+        passMarks:
+          values.passMarks === undefined
+            ? undefined
+            : Number(values.passMarks),
+        venue: values.venue,
+      },
+    });
+    toast({ title: "Schedule added", type: "success" });
+  };
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-[24px] font-[600] text-[#021034]">
+            Exam schedule
+          </h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            {examQuery.data?.name ?? "…"} ·{" "}
+            {formatClassLabel(
+              examQuery.data?.className,
+              examQuery.data?.classSection,
+            )}
+          </p>
+        </div>
+        <Button variant="dark" onClick={() => setDialogOpen(true)}>
+          + Add subject
+        </Button>
+      </div>
+
+      <ExamSubnav examId={examId} />
+
+      {schedulesQuery.isLoading ? (
+        <DataTableSkeleton
+          rows={6}
+          columns={[
+            { headerWidth: "w-32", cellWidth: "w-40" },
+            { headerWidth: "w-24", cellWidth: "w-28" },
+            { headerWidth: "w-20", cellWidth: "w-24" },
+            { headerWidth: "w-20", cellWidth: "w-24" },
+            { headerWidth: "w-24", cellWidth: "w-28" },
+          ]}
+        />
+      ) : schedulesQuery.error ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-slate-700">Failed to load schedule.</p>
+            <Button
+              variant="dark"
+              onClick={() => void schedulesQuery.refetch()}
+            >
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-slate-500">
+                  <th className="py-2 pr-3">Subject</th>
+                  <th className="py-2 pr-3">Date</th>
+                  <th className="hidden py-2 pr-3 md:table-cell">Time</th>
+                  <th className="py-2 pr-3">Max</th>
+                  <th className="py-2 pr-3">Pass</th>
+                  <th className="py-2">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(schedulesQuery.data ?? []).length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="py-8 text-center text-slate-500">
+                      No subjects scheduled yet.
+                    </td>
+                  </tr>
+                ) : (
+                  schedulesQuery.data!.map((s) => (
+                    <tr key={s.id} className="border-t border-slate-100">
+                      <td className="py-3 pr-3 font-medium text-[#021034]">
+                        {s.subjectName}
+                      </td>
+                      <td className="py-3 pr-3">{s.examDate}</td>
+                      <td className="hidden py-3 pr-3 md:table-cell">
+                        {s.startTime || s.endTime
+                          ? `${s.startTime ?? ""}–${s.endTime ?? ""}`
+                          : "—"}
+                      </td>
+                      <td className="py-3 pr-3">{s.maxMarks}</td>
+                      <td className="py-3 pr-3">{s.passMarks}</td>
+                      <td className="py-3">
+                        <Button
+                          variant="ghost"
+                          onClick={() =>
+                            void mutations.deleteSchedule
+                              .mutateAsync({ examId, scheduleId: s.id })
+                              .then(() =>
+                                toast({
+                                  title: "Schedule removed",
+                                  type: "success",
+                                }),
+                              )
+                              .catch(() =>
+                                toast({
+                                  title: "Failed to delete",
+                                  type: "error",
+                                }),
+                              )
+                          }
+                        >
+                          Delete
+                        </Button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+
+      <ScheduleDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onSubmit={handleCreate}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/exams/list/page.tsx
+++ b/src/app/admin/exams/list/page.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { DataTableSkeleton } from "@/components/skeletons";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  ExamDialog,
+  ExamSubnav,
+  EXAM_STATUS_LABELS,
+  EXAM_TYPE_LABELS,
+  examStatusClass,
+  formatClassLabel,
+  useExamMutations,
+  useExams,
+  type Exam,
+  type ExamStatus,
+} from "@/modules/exams";
+import type { CreateExamValues } from "@/modules/exams";
+
+const NEXT_STATUS: Partial<Record<ExamStatus, ExamStatus>> = {
+  DRAFT: "SCHEDULED",
+  SCHEDULED: "IN_PROGRESS",
+  IN_PROGRESS: "COMPLETED",
+};
+
+export default function AdminExamsListPage() {
+  const { toast } = useToast();
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<Exam | null>(null);
+
+  const { data, isLoading, error, refetch } = useExams({
+    page,
+    limit: 10,
+    search: search || undefined,
+  });
+  const mutations = useExamMutations();
+  const totalPages = Math.max(1, Math.ceil((data?.total ?? 0) / 10));
+
+  const handleSave = async (values: CreateExamValues) => {
+    if (editing) {
+      await mutations.updateExam.mutateAsync({
+        id: editing.id,
+        payload: values,
+      });
+      toast({ title: "Exam updated", type: "success" });
+    } else {
+      await mutations.createExam.mutateAsync(values);
+      toast({ title: "Exam created", type: "success" });
+    }
+  };
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-[24px] font-[600] text-[#021034]">Exams</h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            Create and manage examinations
+          </p>
+        </div>
+        <Button
+          variant="dark"
+          onClick={() => {
+            setEditing(null);
+            setDialogOpen(true);
+          }}
+        >
+          + Create exam
+        </Button>
+      </div>
+
+      <ExamSubnav />
+
+      <div className="mb-4">
+        <input
+          className="w-full max-w-sm rounded border border-slate-200 bg-white px-3 py-2 text-sm"
+          placeholder="Search exams"
+          value={search}
+          onChange={(e) => {
+            setPage(1);
+            setSearch(e.target.value);
+          }}
+        />
+      </div>
+
+      {isLoading ? (
+        <DataTableSkeleton
+          rows={8}
+          columns={[
+            { headerWidth: "w-40", cellWidth: "w-48" },
+            { headerWidth: "w-24", cellWidth: "w-28", hideOnMobile: true },
+            { headerWidth: "w-24", cellWidth: "w-28" },
+            { headerWidth: "w-20", cellWidth: "w-24" },
+            { headerWidth: "w-32", cellWidth: "w-40" },
+          ]}
+        />
+      ) : error ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-slate-700">Failed to load exams.</p>
+            <Button variant="dark" onClick={() => void refetch()}>
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-slate-500">
+                  <th className="py-2 pr-3">Name</th>
+                  <th className="hidden py-2 pr-3 md:table-cell">Class</th>
+                  <th className="hidden py-2 pr-3 md:table-cell">Type</th>
+                  <th className="py-2 pr-3">Status</th>
+                  <th className="py-2">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(data?.data ?? []).length === 0 ? (
+                  <tr>
+                    <td colSpan={5} className="py-8 text-center text-slate-500">
+                      No exams found.
+                    </td>
+                  </tr>
+                ) : (
+                  data!.data.map((exam) => {
+                    const next = NEXT_STATUS[exam.status];
+                    return (
+                      <tr key={exam.id} className="border-t border-slate-100">
+                        <td className="py-3 pr-3 font-medium text-[#021034]">
+                          {exam.name}
+                          <div className="text-xs text-slate-500">
+                            {exam.academicYear}
+                          </div>
+                        </td>
+                        <td className="hidden py-3 pr-3 md:table-cell">
+                          {formatClassLabel(exam.className, exam.classSection)}
+                        </td>
+                        <td className="hidden py-3 pr-3 md:table-cell">
+                          {EXAM_TYPE_LABELS[exam.examType]}
+                        </td>
+                        <td className="py-3 pr-3">
+                          <span
+                            className={`rounded px-2 py-0.5 text-xs font-medium ${examStatusClass(exam.status)}`}
+                          >
+                            {EXAM_STATUS_LABELS[exam.status]}
+                          </span>
+                        </td>
+                        <td className="py-3">
+                          <div className="flex flex-wrap gap-1">
+                            <Link href={`/admin/exams/${exam.id}/schedule`}>
+                              <Button variant="ghost">Open</Button>
+                            </Link>
+                            <Button
+                              variant="ghost"
+                              onClick={() => {
+                                setEditing(exam);
+                                setDialogOpen(true);
+                              }}
+                            >
+                              Edit
+                            </Button>
+                            {next ? (
+                              <Button
+                                variant="ghost"
+                                onClick={() =>
+                                  void mutations.updateStatus
+                                    .mutateAsync({
+                                      id: exam.id,
+                                      status: next,
+                                    })
+                                    .then(() =>
+                                      toast({
+                                        title: `Status → ${EXAM_STATUS_LABELS[next]}`,
+                                        type: "success",
+                                      }),
+                                    )
+                                    .catch((err: unknown) => {
+                                      const msg =
+                                        (err as { response?: { data?: { message?: string } } })
+                                          ?.response?.data?.message ??
+                                        "Status update failed";
+                                      toast({
+                                        title: String(msg),
+                                        type: "error",
+                                      });
+                                    })
+                                }
+                              >
+                                → {EXAM_STATUS_LABELS[next]}
+                              </Button>
+                            ) : null}
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+          <div className="mt-4 flex items-center justify-between">
+            <Button
+              variant="ghost"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+            >
+              Previous
+            </Button>
+            <span className="text-sm text-slate-500">
+              Page {page} of {totalPages}
+            </span>
+            <Button
+              variant="ghost"
+              disabled={page >= totalPages}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </Card>
+      )}
+
+      <ExamDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onSubmit={handleSave}
+        initial={editing}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/exams/page.tsx
+++ b/src/app/admin/exams/page.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import Link from "next/link";
+import {
+  BookOpen,
+  CalendarDays,
+  ClipboardCheck,
+  FileCheck2,
+} from "lucide-react";
+import StatCard from "@/components/admin/StatCard";
+import Card from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import { StatCardsGridSkeleton } from "@/components/skeletons";
+import {
+  ExamSubnav,
+  EXAM_STATUS_LABELS,
+  examStatusClass,
+  formatClassLabel,
+  useExamDashboard,
+} from "@/modules/exams";
+
+export default function AdminExamsDashboardPage() {
+  const { data, isLoading, error, refetch } = useExamDashboard();
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-[24px] font-[600] text-[#021034]">
+            Exams & Results
+          </h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            Dashboard, schedules, marks, and report cards
+          </p>
+        </div>
+        <Link href="/admin/exams/list">
+          <Button variant="dark">Manage exams</Button>
+        </Link>
+      </div>
+
+      <ExamSubnav />
+
+      {isLoading ? (
+        <StatCardsGridSkeleton count={4} />
+      ) : error ? (
+        <Card>
+          <div className="flex flex-col gap-3 p-2">
+            <p className="text-sm text-slate-700">
+              Failed to load exam dashboard.
+            </p>
+            <Button variant="dark" onClick={() => void refetch()}>
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : (
+        <>
+          <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <StatCard
+              label="Total exams"
+              value={String(data?.totalExams ?? 0)}
+              icon={BookOpen}
+              className="bg-white border-[#BFDBFE]"
+              iconBgColor="bg-[#BFDBFE]"
+              progressLabel=" "
+            />
+            <StatCard
+              label="Scheduled"
+              value={String(data?.scheduledCount ?? 0)}
+              icon={CalendarDays}
+              className="bg-white border-[#BFDBFE]"
+              iconBgColor="bg-[#BFDBFE]"
+              progressLabel=" "
+            />
+            <StatCard
+              label="Pending marks"
+              value={String(data?.pendingMarksCount ?? 0)}
+              icon={ClipboardCheck}
+              className="bg-white border-[#BFDBFE]"
+              iconBgColor="bg-[#BFDBFE]"
+              progressLabel=" "
+            />
+            <StatCard
+              label="Published"
+              value={String(data?.publishedCount ?? 0)}
+              icon={FileCheck2}
+              className="bg-white border-[#BFDBFE]"
+              iconBgColor="bg-[#BFDBFE]"
+              progressLabel=" "
+            />
+          </section>
+
+          <div className="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <Card>
+              <h2 className="mb-3 text-base font-semibold text-[#021034]">
+                Upcoming schedules
+              </h2>
+              {(data?.upcomingSchedules ?? []).length === 0 ? (
+                <p className="text-sm text-slate-500">No upcoming sittings.</p>
+              ) : (
+                <ul className="space-y-2">
+                  {data!.upcomingSchedules.map((s) => (
+                    <li
+                      key={s.scheduleId}
+                      className="flex flex-wrap items-center justify-between gap-2 rounded border border-slate-100 px-3 py-2 text-sm"
+                    >
+                      <div>
+                        <p className="font-medium text-[#021034]">
+                          {s.examName} · {s.subjectName}
+                        </p>
+                        <p className="text-slate-500">
+                          {s.className ?? "—"} · {s.examDate}
+                          {s.startTime ? ` ${s.startTime}` : ""}
+                        </p>
+                      </div>
+                      <Link href={`/admin/exams/${s.examId}/schedule`}>
+                        <Button variant="ghost">View</Button>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </Card>
+
+            <Card>
+              <h2 className="mb-3 text-base font-semibold text-[#021034]">
+                Recent exams
+              </h2>
+              {(data?.recentExams ?? []).length === 0 ? (
+                <p className="text-sm text-slate-500">No exams yet.</p>
+              ) : (
+                <ul className="space-y-2">
+                  {data!.recentExams.map((exam) => (
+                    <li
+                      key={exam.id}
+                      className="flex flex-wrap items-center justify-between gap-2 rounded border border-slate-100 px-3 py-2 text-sm"
+                    >
+                      <div>
+                        <p className="font-medium text-[#021034]">{exam.name}</p>
+                        <p className="text-slate-500">
+                          {formatClassLabel(exam.className, exam.classSection)}
+                        </p>
+                      </div>
+                      <span
+                        className={`rounded px-2 py-0.5 text-xs font-medium ${examStatusClass(exam.status)}`}
+                      >
+                        {EXAM_STATUS_LABELS[exam.status]}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </Card>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/student/exams/[examId]/page.tsx
+++ b/src/app/student/exams/[examId]/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { use } from "react";
+import Link from "next/link";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { DataTableSkeleton } from "@/components/skeletons";
+import { formatPercent, useMyReportCard } from "@/modules/exams";
+
+export default function StudentReportCardPage({
+  params,
+}: {
+  params: Promise<{ examId: string }>;
+}) {
+  const { examId } = use(params);
+  const { data, isLoading, error, refetch } = useMyReportCard(examId);
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-[24px] font-[600] text-[#021034]">
+            Report card
+          </h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            {data?.exam.name ?? "…"}
+          </p>
+        </div>
+        <Link href="/student/exams">
+          <Button variant="ghost">Back</Button>
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <DataTableSkeleton
+          rows={6}
+          columns={[
+            { headerWidth: "w-32", cellWidth: "w-40" },
+            { headerWidth: "w-20", cellWidth: "w-24" },
+            { headerWidth: "w-16", cellWidth: "w-20" },
+          ]}
+        />
+      ) : error ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-slate-700">
+              Failed to load report card. It may not be published yet.
+            </p>
+            <Button variant="dark" onClick={() => void refetch()}>
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : (
+        <Card>
+          <div className="mb-4 border-b border-slate-100 pb-4">
+            <h2 className="text-lg font-semibold text-[#021034]">
+              {data?.studentName}
+            </h2>
+            {data?.result ? (
+              <p className="mt-2 text-sm">
+                Overall: {data.result.totalObtainedMarks}/
+                {data.result.totalMaxMarks} (
+                {formatPercent(data.result.percentage)}) · Grade{" "}
+                {data.result.grade ?? "—"} · Rank {data.result.rank ?? "—"}
+              </p>
+            ) : null}
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-slate-500">
+                  <th className="py-2 pr-3">Subject</th>
+                  <th className="py-2 pr-3">Marks</th>
+                  <th className="py-2 pr-3">Grade</th>
+                  <th className="py-2">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data!.subjects.map((s) => (
+                  <tr key={s.subjectId} className="border-t border-slate-100">
+                    <td className="py-3 pr-3 font-medium text-[#021034]">
+                      {s.subjectName}
+                    </td>
+                    <td className="py-3 pr-3">
+                      {s.isAbsent
+                        ? "Absent"
+                        : `${s.marksObtained ?? "—"}/${s.maxMarks}`}
+                    </td>
+                    <td className="py-3 pr-3">{s.grade ?? "—"}</td>
+                    <td className="py-3">
+                      {s.isAbsent
+                        ? "Absent"
+                        : s.isPassed
+                          ? "Pass"
+                          : "Fail"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/student/exams/page.tsx
+++ b/src/app/student/exams/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import Link from "next/link";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { DataTableSkeleton } from "@/components/skeletons";
+import {
+  formatPercent,
+  useMyExamResults,
+} from "@/modules/exams";
+
+export default function StudentExamsPage() {
+  const { data, isLoading, error, refetch } = useMyExamResults();
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-6">
+        <h1 className="text-[24px] font-[600] text-[#021034]">My exams</h1>
+        <p className="mt-1 text-[14px] text-[#737373]">
+          Published results and report cards
+        </p>
+      </div>
+
+      {isLoading ? (
+        <DataTableSkeleton
+          rows={6}
+          columns={[
+            { headerWidth: "w-40", cellWidth: "w-48" },
+            { headerWidth: "w-24", cellWidth: "w-28" },
+            { headerWidth: "w-20", cellWidth: "w-24" },
+            { headerWidth: "w-24", cellWidth: "w-28" },
+          ]}
+        />
+      ) : error ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-slate-700">Failed to load results.</p>
+            <Button variant="dark" onClick={() => void refetch()}>
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-slate-500">
+                  <th className="py-2 pr-3">Exam</th>
+                  <th className="hidden py-2 pr-3 md:table-cell">Class</th>
+                  <th className="py-2 pr-3">%</th>
+                  <th className="py-2 pr-3">Grade</th>
+                  <th className="py-2">Report card</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(data ?? []).length === 0 ? (
+                  <tr>
+                    <td colSpan={5} className="py-8 text-center text-slate-500">
+                      No published results yet.
+                    </td>
+                  </tr>
+                ) : (
+                  data!.map((r) => (
+                    <tr key={r.id} className="border-t border-slate-100">
+                      <td className="py-3 pr-3 font-medium text-[#021034]">
+                        {r.examName}
+                      </td>
+                      <td className="hidden py-3 pr-3 md:table-cell">
+                        {r.className ?? "—"}
+                      </td>
+                      <td className="py-3 pr-3">
+                        {formatPercent(r.percentage)}
+                      </td>
+                      <td className="py-3 pr-3">{r.grade ?? "—"}</td>
+                      <td className="py-3">
+                        <Link href={`/student/exams/${r.examId}`}>
+                          <Button variant="ghost">View</Button>
+                        </Link>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/navConfig.ts
+++ b/src/components/layout/navConfig.ts
@@ -50,7 +50,7 @@ export const managementNav = [
   },
   {
     label: "Exams & Results",
-    href: "/admin/staff",
+    href: "/admin/exams",
     icon: BookOpen,
   },
   {
@@ -98,5 +98,10 @@ export const studentNav = [
     label: "My Profile",
     href: "/student/profile",
     icon: GraduationCap,
+  },
+  {
+    label: "My Exams",
+    href: "/student/exams",
+    icon: BookOpen,
   },
 ];

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -33,6 +33,22 @@ export const ADMIN_API = {
   DOCUMENTS: "/admin/documents",
   DOCUMENTS_UPLOAD: "/admin/documents/upload",
   DOCUMENT_BY_ID: (id: string) => `/admin/documents/${id}`,
+  EXAMS_DASHBOARD: "/admin/exams/dashboard",
+  EXAMS: "/admin/exams",
+  EXAM_BY_ID: (id: string) => `/admin/exams/${id}`,
+  EXAM_STATUS: (id: string) => `/admin/exams/${id}/status`,
+  EXAM_SCHEDULES: (examId: string) => `/admin/exams/${examId}/schedules`,
+  EXAM_SCHEDULE_BY_ID: (examId: string, scheduleId: string) =>
+    `/admin/exams/${examId}/schedules/${scheduleId}`,
+  EXAM_MARKS: (examId: string) => `/admin/exams/${examId}/marks`,
+  EXAM_RESULTS: (examId: string) => `/admin/exams/${examId}/results`,
+  EXAM_RESULTS_GENERATE: (examId: string) =>
+    `/admin/exams/${examId}/results/generate`,
+  EXAM_RESULTS_PUBLISH: (examId: string) =>
+    `/admin/exams/${examId}/results/publish`,
+  EXAM_REPORT_CARD: (examId: string, studentUserId: string) =>
+    `/admin/exams/${examId}/report-cards/${studentUserId}`,
+  EXAM_CLASS_REPORT: (examId: string) => `/admin/exams/${examId}/class-report`,
 };
 
 export const TEACHER_API = {
@@ -57,6 +73,8 @@ export const STUDENT_API = {
   BY_ID: (id: string) => `/admin/students/${id}`,
   /** Update student (admin or class teacher) */
   UPDATE: (id: string) => `/students/${id}`,
+  EXAMS: "/student/exams",
+  EXAM_REPORT_CARD: (examId: string) => `/student/exams/${examId}/report-card`,
 };
 
 const routes = {

--- a/src/modules/exams/api/exams.ts
+++ b/src/modules/exams/api/exams.ts
@@ -1,0 +1,173 @@
+import { ADMIN_API, STUDENT_API } from "@/config/api-routes";
+import API from "@/services/axios";
+import type {
+  ClassReport,
+  CreateExamPayload,
+  CreateSchedulePayload,
+  Exam,
+  ExamDashboardStats,
+  ExamMarksGrid,
+  ExamMark,
+  ExamResult,
+  ExamSchedule,
+  ExamStatus,
+  Paginated,
+  ReportCard,
+  UpsertMarkItem,
+} from "@/modules/exams/types";
+
+export async function fetchExamDashboard(): Promise<ExamDashboardStats> {
+  const res = await API.get<ExamDashboardStats>(ADMIN_API.EXAMS_DASHBOARD);
+  return res.data;
+}
+
+export async function fetchExams(
+  params: {
+    page?: number;
+    limit?: number;
+    search?: string;
+    classId?: string;
+    academicYear?: string;
+    examType?: string;
+    status?: string;
+  } = {},
+): Promise<Paginated<Exam>> {
+  const res = await API.get<Paginated<Exam>>(ADMIN_API.EXAMS, { params });
+  return res.data;
+}
+
+export async function fetchExam(id: string): Promise<Exam> {
+  const res = await API.get<Exam>(ADMIN_API.EXAM_BY_ID(id));
+  return res.data;
+}
+
+export async function createExam(payload: CreateExamPayload): Promise<Exam> {
+  const res = await API.post<Exam>(ADMIN_API.EXAMS, payload);
+  return res.data;
+}
+
+export async function updateExam(
+  id: string,
+  payload: Partial<CreateExamPayload>,
+): Promise<Exam> {
+  const res = await API.patch<Exam>(ADMIN_API.EXAM_BY_ID(id), payload);
+  return res.data;
+}
+
+export async function updateExamStatus(
+  id: string,
+  status: ExamStatus,
+): Promise<Exam> {
+  const res = await API.patch<Exam>(ADMIN_API.EXAM_STATUS(id), { status });
+  return res.data;
+}
+
+export async function deleteExam(id: string): Promise<void> {
+  await API.delete(ADMIN_API.EXAM_BY_ID(id));
+}
+
+export async function fetchExamSchedules(
+  examId: string,
+): Promise<ExamSchedule[]> {
+  const res = await API.get<ExamSchedule[]>(ADMIN_API.EXAM_SCHEDULES(examId));
+  return res.data;
+}
+
+export async function createExamSchedule(
+  examId: string,
+  payload: CreateSchedulePayload,
+): Promise<ExamSchedule> {
+  const res = await API.post<ExamSchedule>(
+    ADMIN_API.EXAM_SCHEDULES(examId),
+    payload,
+  );
+  return res.data;
+}
+
+export async function updateExamSchedule(
+  examId: string,
+  scheduleId: string,
+  payload: Partial<CreateSchedulePayload>,
+): Promise<ExamSchedule> {
+  const res = await API.patch<ExamSchedule>(
+    ADMIN_API.EXAM_SCHEDULE_BY_ID(examId, scheduleId),
+    payload,
+  );
+  return res.data;
+}
+
+export async function deleteExamSchedule(
+  examId: string,
+  scheduleId: string,
+): Promise<void> {
+  await API.delete(ADMIN_API.EXAM_SCHEDULE_BY_ID(examId, scheduleId));
+}
+
+export async function fetchExamMarks(examId: string): Promise<ExamMarksGrid> {
+  const res = await API.get<ExamMarksGrid>(ADMIN_API.EXAM_MARKS(examId));
+  return res.data;
+}
+
+export async function upsertExamMarks(
+  examId: string,
+  marks: UpsertMarkItem[],
+): Promise<ExamMark[]> {
+  const res = await API.put<ExamMark[]>(ADMIN_API.EXAM_MARKS(examId), {
+    marks,
+  });
+  return res.data;
+}
+
+export async function generateExamResults(
+  examId: string,
+): Promise<ExamResult[]> {
+  const res = await API.post<ExamResult[]>(
+    ADMIN_API.EXAM_RESULTS_GENERATE(examId),
+  );
+  return res.data;
+}
+
+export async function publishExamResults(
+  examId: string,
+): Promise<ExamResult[]> {
+  const res = await API.post<ExamResult[]>(
+    ADMIN_API.EXAM_RESULTS_PUBLISH(examId),
+  );
+  return res.data;
+}
+
+export async function fetchExamResults(
+  examId: string,
+  params: { page?: number; limit?: number; search?: string } = {},
+): Promise<Paginated<ExamResult>> {
+  const res = await API.get<Paginated<ExamResult>>(
+    ADMIN_API.EXAM_RESULTS(examId),
+    { params },
+  );
+  return res.data;
+}
+
+export async function fetchReportCard(
+  examId: string,
+  studentUserId: string,
+): Promise<ReportCard> {
+  const res = await API.get<ReportCard>(
+    ADMIN_API.EXAM_REPORT_CARD(examId, studentUserId),
+  );
+  return res.data;
+}
+
+export async function fetchClassReport(examId: string): Promise<ClassReport> {
+  const res = await API.get<ClassReport>(ADMIN_API.EXAM_CLASS_REPORT(examId));
+  return res.data;
+}
+
+export async function fetchMyExamResults(): Promise<ExamResult[]> {
+  const res = await API.get<ExamResult[]>(STUDENT_API.EXAMS);
+  return res.data;
+}
+
+export async function fetchMyReportCard(examId: string): Promise<ReportCard> {
+  const res = await API.get<ReportCard>(STUDENT_API.EXAM_REPORT_CARD(examId));
+  return res.data;
+}

--- a/src/modules/exams/components/ExamDialog.tsx
+++ b/src/modules/exams/components/ExamDialog.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useForm, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import axios from "axios";
+import Button from "@/components/ui/Button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/Form";
+import { Input } from "@/components/ui/Input";
+import { fetchClasses, type ClassItem } from "@/modules/classes";
+import {
+  createExamSchema,
+  type CreateExamValues,
+} from "@/modules/exams/schemas/exam.schemas";
+import type { Exam } from "@/modules/exams/types";
+import { EXAM_TYPE_LABELS } from "@/modules/exams/utils/format";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (values: CreateExamValues) => Promise<void>;
+  initial?: Exam | null;
+};
+
+export function ExamDialog({ open, onClose, onSubmit, initial }: Props) {
+  const [classes, setClasses] = useState<ClassItem[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const form = useForm<CreateExamValues>({
+    resolver: zodResolver(
+      createExamSchema,
+    ) as unknown as Resolver<CreateExamValues>,
+    mode: "onChange",
+    defaultValues: {
+      name: "",
+      academicYear: "",
+      examType: "MIDTERM",
+      classId: "",
+      startDate: "",
+      endDate: "",
+      description: "",
+    },
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    void fetchClasses({ page: 1, pageSize: 1000 }).then((res) => {
+      setClasses(res.classes ?? []);
+    });
+    if (initial) {
+      form.reset({
+        name: initial.name,
+        academicYear: initial.academicYear,
+        examType: initial.examType,
+        classId: initial.classId,
+        startDate: initial.startDate ?? "",
+        endDate: initial.endDate ?? "",
+        description: initial.description ?? "",
+      });
+    } else {
+      form.reset({
+        name: "",
+        academicYear: "",
+        examType: "MIDTERM",
+        classId: "",
+        startDate: "",
+        endDate: "",
+        description: "",
+      });
+    }
+  }, [open, initial, form]);
+
+  if (!open) return null;
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    setSaving(true);
+    try {
+      await onSubmit({
+        ...values,
+        startDate: values.startDate || undefined,
+        endDate: values.endDate || undefined,
+        description: values.description || undefined,
+      });
+      onClose();
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err)) {
+        const message =
+          (err.response?.data as { message?: string })?.message ??
+          "Failed to save exam";
+        form.setError("root", { message: String(message) });
+      }
+    } finally {
+      setSaving(false);
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-lg rounded-lg bg-white p-5 shadow-lg">
+        <h2 className="mb-4 text-lg font-semibold text-[#021034]">
+          {initial ? "Edit exam" : "Create exam"}
+        </h2>
+        <Form onSubmit={handleSubmit}>
+          <FormField>
+            <FormLabel>Name</FormLabel>
+            <FormControl>
+              <Input {...form.register("name")} placeholder="Mid Term 2025-26" />
+            </FormControl>
+            <FormMessage>{form.formState.errors.name?.message}</FormMessage>
+          </FormField>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <FormField>
+              <FormLabel>Academic year</FormLabel>
+              <FormControl>
+                <Input {...form.register("academicYear")} placeholder="2025-26" />
+              </FormControl>
+              <FormMessage>
+                {form.formState.errors.academicYear?.message}
+              </FormMessage>
+            </FormField>
+            <FormField>
+              <FormLabel>Type</FormLabel>
+              <FormControl>
+                <select
+                  {...form.register("examType")}
+                  className="w-full rounded border border-slate-200 bg-white px-3 py-2 text-sm"
+                >
+                  {Object.entries(EXAM_TYPE_LABELS).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </FormControl>
+              <FormMessage>
+                {form.formState.errors.examType?.message}
+              </FormMessage>
+            </FormField>
+          </div>
+          <FormField>
+            <FormLabel>Class</FormLabel>
+            <FormControl>
+              <select
+                {...form.register("classId")}
+                className="w-full rounded border border-slate-200 bg-white px-3 py-2 text-sm"
+              >
+                <option value="">Select class</option>
+                {classes.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                    {c.section ? `-${c.section}` : ""}
+                  </option>
+                ))}
+              </select>
+            </FormControl>
+            <FormMessage>{form.formState.errors.classId?.message}</FormMessage>
+          </FormField>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <FormField>
+              <FormLabel>Start date</FormLabel>
+              <FormControl>
+                <Input type="date" {...form.register("startDate")} />
+              </FormControl>
+              <FormMessage>
+                {form.formState.errors.startDate?.message}
+              </FormMessage>
+            </FormField>
+            <FormField>
+              <FormLabel>End date</FormLabel>
+              <FormControl>
+                <Input type="date" {...form.register("endDate")} />
+              </FormControl>
+              <FormMessage>
+                {form.formState.errors.endDate?.message}
+              </FormMessage>
+            </FormField>
+          </div>
+          <FormField>
+            <FormLabel>Description</FormLabel>
+            <FormControl>
+              <Input
+                {...form.register("description")}
+                placeholder="Optional notes"
+              />
+            </FormControl>
+            <FormMessage>
+              {form.formState.errors.description?.message}
+            </FormMessage>
+          </FormField>
+          {form.formState.errors.root?.message ? (
+            <p className="text-sm text-red-600">
+              {form.formState.errors.root.message}
+            </p>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="dark" disabled={saving}>
+              {saving ? "Saving…" : initial ? "Save" : "Create"}
+            </Button>
+          </div>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/exams/components/ExamSubnav.tsx
+++ b/src/modules/exams/components/ExamSubnav.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const links = [
+  { href: "/admin/exams", label: "Dashboard", exact: true },
+  { href: "/admin/exams/list", label: "Exams" },
+];
+
+type Props = {
+  examId?: string;
+};
+
+export function ExamSubnav({ examId }: Props) {
+  const pathname = usePathname();
+
+  const examLinks = examId
+    ? [
+        { href: `/admin/exams/${examId}/schedule`, label: "Schedule" },
+        { href: `/admin/exams/${examId}/marks`, label: "Marks" },
+        { href: `/admin/exams/${examId}/results`, label: "Results" },
+        { href: `/admin/exams/${examId}/report-cards`, label: "Report cards" },
+        { href: `/admin/exams/${examId}/class-report`, label: "Class report" },
+      ]
+    : [];
+
+  const all = [...links, ...examLinks];
+
+  return (
+    <div className="mb-6 flex flex-wrap gap-2">
+      {all.map((link) => {
+        const exact = "exact" in link && link.exact;
+        const active = exact
+          ? pathname === link.href
+          : pathname === link.href || pathname.startsWith(`${link.href}/`);
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={`rounded-md px-3 py-1.5 text-sm font-medium ${
+              active
+                ? "bg-[#DBEAFE] text-[#021034]"
+                : "bg-white text-slate-600 border border-slate-200 hover:bg-slate-50"
+            }`}
+          >
+            {link.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/modules/exams/components/ScheduleDialog.tsx
+++ b/src/modules/exams/components/ScheduleDialog.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useForm, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import axios from "axios";
+import Button from "@/components/ui/Button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/Form";
+import { Input } from "@/components/ui/Input";
+import { fetchSubjects } from "@/modules/subjects/api/subjects";
+import type { Subject } from "@/modules/subjects/types/subjects";
+import {
+  createScheduleSchema,
+  type CreateScheduleValues,
+} from "@/modules/exams/schemas/exam.schemas";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (values: CreateScheduleValues) => Promise<void>;
+};
+
+export function ScheduleDialog({ open, onClose, onSubmit }: Props) {
+  const [subjects, setSubjects] = useState<Subject[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const form = useForm<CreateScheduleValues>({
+    resolver: zodResolver(
+      createScheduleSchema,
+    ) as unknown as Resolver<CreateScheduleValues>,
+    mode: "onChange",
+    defaultValues: {
+      subjectId: "",
+      examDate: "",
+      startTime: "",
+      endTime: "",
+      maxMarks: 100,
+      passMarks: 33,
+      venue: "",
+    },
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    void fetchSubjects({ page: 1, pageSize: 200 }).then((res) => {
+      setSubjects(res.subjects ?? []);
+    });
+    form.reset({
+      subjectId: "",
+      examDate: "",
+      startTime: "",
+      endTime: "",
+      maxMarks: 100,
+      passMarks: 33,
+      venue: "",
+    });
+  }, [open, form]);
+
+  if (!open) return null;
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    setSaving(true);
+    try {
+      await onSubmit({
+        ...values,
+        startTime: values.startTime || undefined,
+        endTime: values.endTime || undefined,
+        venue: values.venue || undefined,
+      });
+      onClose();
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err)) {
+        const message =
+          (err.response?.data as { message?: string | string[] })?.message;
+        form.setError("root", {
+          message: Array.isArray(message)
+            ? message.join(", ")
+            : String(message ?? "Failed to save schedule"),
+        });
+      }
+    } finally {
+      setSaving(false);
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-lg rounded-lg bg-white p-5 shadow-lg">
+        <h2 className="mb-4 text-lg font-semibold text-[#021034]">
+          Add subject schedule
+        </h2>
+        <Form onSubmit={handleSubmit}>
+          <FormField>
+            <FormLabel>Subject</FormLabel>
+            <FormControl>
+              <select
+                {...form.register("subjectId")}
+                className="w-full rounded border border-slate-200 bg-white px-3 py-2 text-sm"
+              >
+                <option value="">Select subject</option>
+                {subjects.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name}
+                    {s.code ? ` (${s.code})` : ""}
+                  </option>
+                ))}
+              </select>
+            </FormControl>
+            <FormMessage>
+              {form.formState.errors.subjectId?.message}
+            </FormMessage>
+          </FormField>
+          <FormField>
+            <FormLabel>Exam date</FormLabel>
+            <FormControl>
+              <Input type="date" {...form.register("examDate")} />
+            </FormControl>
+            <FormMessage>
+              {form.formState.errors.examDate?.message}
+            </FormMessage>
+          </FormField>
+          <div className="grid grid-cols-2 gap-3">
+            <FormField>
+              <FormLabel>Start time</FormLabel>
+              <FormControl>
+                <Input type="time" {...form.register("startTime")} />
+              </FormControl>
+              <FormMessage>
+                {form.formState.errors.startTime?.message}
+              </FormMessage>
+            </FormField>
+            <FormField>
+              <FormLabel>End time</FormLabel>
+              <FormControl>
+                <Input type="time" {...form.register("endTime")} />
+              </FormControl>
+              <FormMessage>
+                {form.formState.errors.endTime?.message}
+              </FormMessage>
+            </FormField>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <FormField>
+              <FormLabel>Max marks</FormLabel>
+              <FormControl>
+                <Input type="number" {...form.register("maxMarks")} />
+              </FormControl>
+              <FormMessage>
+                {form.formState.errors.maxMarks?.message}
+              </FormMessage>
+            </FormField>
+            <FormField>
+              <FormLabel>Pass marks</FormLabel>
+              <FormControl>
+                <Input type="number" {...form.register("passMarks")} />
+              </FormControl>
+              <FormMessage>
+                {form.formState.errors.passMarks?.message}
+              </FormMessage>
+            </FormField>
+          </div>
+          <FormField>
+            <FormLabel>Venue</FormLabel>
+            <FormControl>
+              <Input {...form.register("venue")} placeholder="Hall A" />
+            </FormControl>
+            <FormMessage>{form.formState.errors.venue?.message}</FormMessage>
+          </FormField>
+          {form.formState.errors.root?.message ? (
+            <p className="text-sm text-red-600">
+              {form.formState.errors.root.message}
+            </p>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="dark" disabled={saving}>
+              {saving ? "Saving…" : "Add"}
+            </Button>
+          </div>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/exams/constants/query-keys.ts
+++ b/src/modules/exams/constants/query-keys.ts
@@ -1,0 +1,21 @@
+export const EXAMS_PAGE_SIZE = 10;
+
+export const examQueryKeys = {
+  all: ["exams"] as const,
+  dashboard: () => [...examQueryKeys.all, "dashboard"] as const,
+  list: (q?: Record<string, unknown>) =>
+    [...examQueryKeys.all, "list", q ?? {}] as const,
+  detail: (id: string) => [...examQueryKeys.all, "detail", id] as const,
+  schedules: (examId: string) =>
+    [...examQueryKeys.all, "schedules", examId] as const,
+  marks: (examId: string) => [...examQueryKeys.all, "marks", examId] as const,
+  results: (examId: string, q?: Record<string, unknown>) =>
+    [...examQueryKeys.all, "results", examId, q ?? {}] as const,
+  reportCard: (examId: string, studentUserId: string) =>
+    [...examQueryKeys.all, "report-card", examId, studentUserId] as const,
+  classReport: (examId: string) =>
+    [...examQueryKeys.all, "class-report", examId] as const,
+  studentList: () => [...examQueryKeys.all, "student-list"] as const,
+  studentReportCard: (examId: string) =>
+    [...examQueryKeys.all, "student-report-card", examId] as const,
+};

--- a/src/modules/exams/hooks/useExams.ts
+++ b/src/modules/exams/hooks/useExams.ts
@@ -1,0 +1,206 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createExam,
+  createExamSchedule,
+  deleteExam,
+  deleteExamSchedule,
+  fetchClassReport,
+  fetchExam,
+  fetchExamDashboard,
+  fetchExamMarks,
+  fetchExamResults,
+  fetchExamSchedules,
+  fetchExams,
+  fetchMyExamResults,
+  fetchMyReportCard,
+  fetchReportCard,
+  generateExamResults,
+  publishExamResults,
+  updateExam,
+  updateExamStatus,
+  upsertExamMarks,
+} from "@/modules/exams/api/exams";
+import {
+  EXAMS_PAGE_SIZE,
+  examQueryKeys,
+} from "@/modules/exams/constants/query-keys";
+import type {
+  CreateExamPayload,
+  CreateSchedulePayload,
+  ExamStatus,
+  UpsertMarkItem,
+} from "@/modules/exams/types";
+
+export function useExamDashboard() {
+  return useQuery({
+    queryKey: examQueryKeys.dashboard(),
+    queryFn: fetchExamDashboard,
+  });
+}
+
+export function useExams(
+  query: {
+    page?: number;
+    limit?: number;
+    search?: string;
+    classId?: string;
+    status?: string;
+    academicYear?: string;
+  } = {},
+) {
+  return useQuery({
+    queryKey: examQueryKeys.list(query),
+    queryFn: () =>
+      fetchExams({
+        page: query.page ?? 1,
+        limit: query.limit ?? EXAMS_PAGE_SIZE,
+        search: query.search,
+        classId: query.classId,
+        status: query.status,
+        academicYear: query.academicYear,
+      }),
+  });
+}
+
+export function useExam(examId: string) {
+  return useQuery({
+    queryKey: examQueryKeys.detail(examId),
+    queryFn: () => fetchExam(examId),
+    enabled: Boolean(examId),
+  });
+}
+
+export function useExamSchedules(examId: string) {
+  return useQuery({
+    queryKey: examQueryKeys.schedules(examId),
+    queryFn: () => fetchExamSchedules(examId),
+    enabled: Boolean(examId),
+  });
+}
+
+export function useExamMarks(examId: string) {
+  return useQuery({
+    queryKey: examQueryKeys.marks(examId),
+    queryFn: () => fetchExamMarks(examId),
+    enabled: Boolean(examId),
+  });
+}
+
+export function useExamResults(
+  examId: string,
+  query: { page?: number; limit?: number; search?: string } = {},
+) {
+  return useQuery({
+    queryKey: examQueryKeys.results(examId, query),
+    queryFn: () =>
+      fetchExamResults(examId, {
+        page: query.page ?? 1,
+        limit: query.limit ?? EXAMS_PAGE_SIZE,
+        search: query.search,
+      }),
+    enabled: Boolean(examId),
+  });
+}
+
+export function useReportCard(examId: string, studentUserId: string) {
+  return useQuery({
+    queryKey: examQueryKeys.reportCard(examId, studentUserId),
+    queryFn: () => fetchReportCard(examId, studentUserId),
+    enabled: Boolean(examId && studentUserId),
+  });
+}
+
+export function useClassReport(examId: string) {
+  return useQuery({
+    queryKey: examQueryKeys.classReport(examId),
+    queryFn: () => fetchClassReport(examId),
+    enabled: Boolean(examId),
+  });
+}
+
+export function useMyExamResults() {
+  return useQuery({
+    queryKey: examQueryKeys.studentList(),
+    queryFn: fetchMyExamResults,
+  });
+}
+
+export function useMyReportCard(examId: string) {
+  return useQuery({
+    queryKey: examQueryKeys.studentReportCard(examId),
+    queryFn: () => fetchMyReportCard(examId),
+    enabled: Boolean(examId),
+  });
+}
+
+export function useExamMutations() {
+  const queryClient = useQueryClient();
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: examQueryKeys.all });
+
+  return {
+    createExam: useMutation({
+      mutationFn: (payload: CreateExamPayload) => createExam(payload),
+      onSuccess: invalidate,
+    }),
+    updateExam: useMutation({
+      mutationFn: ({
+        id,
+        payload,
+      }: {
+        id: string;
+        payload: Partial<CreateExamPayload>;
+      }) => updateExam(id, payload),
+      onSuccess: invalidate,
+    }),
+    updateStatus: useMutation({
+      mutationFn: ({ id, status }: { id: string; status: ExamStatus }) =>
+        updateExamStatus(id, status),
+      onSuccess: invalidate,
+    }),
+    deleteExam: useMutation({
+      mutationFn: (id: string) => deleteExam(id),
+      onSuccess: invalidate,
+    }),
+    createSchedule: useMutation({
+      mutationFn: ({
+        examId,
+        payload,
+      }: {
+        examId: string;
+        payload: CreateSchedulePayload;
+      }) => createExamSchedule(examId, payload),
+      onSuccess: invalidate,
+    }),
+    deleteSchedule: useMutation({
+      mutationFn: ({
+        examId,
+        scheduleId,
+      }: {
+        examId: string;
+        scheduleId: string;
+      }) => deleteExamSchedule(examId, scheduleId),
+      onSuccess: invalidate,
+    }),
+    upsertMarks: useMutation({
+      mutationFn: ({
+        examId,
+        marks,
+      }: {
+        examId: string;
+        marks: UpsertMarkItem[];
+      }) => upsertExamMarks(examId, marks),
+      onSuccess: invalidate,
+    }),
+    generateResults: useMutation({
+      mutationFn: (examId: string) => generateExamResults(examId),
+      onSuccess: invalidate,
+    }),
+    publishResults: useMutation({
+      mutationFn: (examId: string) => publishExamResults(examId),
+      onSuccess: invalidate,
+    }),
+  };
+}

--- a/src/modules/exams/index.ts
+++ b/src/modules/exams/index.ts
@@ -1,0 +1,9 @@
+export * from "./types";
+export * from "./api/exams";
+export * from "./hooks/useExams";
+export * from "./constants/query-keys";
+export * from "./utils/format";
+export * from "./schemas/exam.schemas";
+export { ExamSubnav } from "./components/ExamSubnav";
+export { ExamDialog } from "./components/ExamDialog";
+export { ScheduleDialog } from "./components/ScheduleDialog";

--- a/src/modules/exams/schemas/exam.schemas.ts
+++ b/src/modules/exams/schemas/exam.schemas.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const createExamSchema = z.object({
+  name: z.string().min(1, "Name is required").max(200),
+  academicYear: z.string().min(1, "Academic year is required").max(20),
+  examType: z.enum(["UNIT_TEST", "MIDTERM", "FINAL", "PRACTICAL", "OTHER"]),
+  classId: z.string().uuid("Select a class"),
+  startDate: z.string().optional().or(z.literal("")),
+  endDate: z.string().optional().or(z.literal("")),
+  description: z.string().max(1000).optional().or(z.literal("")),
+});
+
+export type CreateExamValues = z.infer<typeof createExamSchema>;
+
+export const createScheduleSchema = z.object({
+  subjectId: z.string().uuid("Select a subject"),
+  examDate: z.string().min(1, "Exam date is required"),
+  startTime: z.string().optional().or(z.literal("")),
+  endTime: z.string().optional().or(z.literal("")),
+  maxMarks: z.coerce.number().min(1).max(1000),
+  passMarks: z.coerce.number().min(0).max(1000).optional(),
+  venue: z.string().max(200).optional().or(z.literal("")),
+});
+
+export type CreateScheduleValues = z.infer<typeof createScheduleSchema>;

--- a/src/modules/exams/types/index.ts
+++ b/src/modules/exams/types/index.ts
@@ -1,0 +1,192 @@
+export type ExamType =
+  | "UNIT_TEST"
+  | "MIDTERM"
+  | "FINAL"
+  | "PRACTICAL"
+  | "OTHER";
+
+export type ExamStatus =
+  | "DRAFT"
+  | "SCHEDULED"
+  | "IN_PROGRESS"
+  | "COMPLETED"
+  | "RESULTS_PUBLISHED"
+  | "CANCELLED";
+
+export type ResultStatus = "DRAFT" | "PUBLISHED";
+
+export type Paginated<T> = {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
+export type Exam = {
+  id: string;
+  schoolId: string;
+  name: string;
+  academicYear: string;
+  examType: ExamType;
+  classId: string;
+  className?: string | null;
+  classSection?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  status: ExamStatus;
+  description?: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ExamSchedule = {
+  id: string;
+  schoolId: string;
+  examId: string;
+  subjectId: string;
+  subjectName?: string | null;
+  subjectCode?: string | null;
+  examDate: string;
+  startTime?: string | null;
+  endTime?: string | null;
+  maxMarks: number;
+  passMarks: number;
+  venue?: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ExamMark = {
+  id: string;
+  examId: string;
+  scheduleId: string;
+  studentUserId: string;
+  studentName?: string | null;
+  studentCode?: string | null;
+  subjectId?: string | null;
+  subjectName?: string | null;
+  marksObtained?: number | null;
+  maxMarks?: number | null;
+  passMarks?: number | null;
+  grade?: string | null;
+  isAbsent: boolean;
+  isPassed: boolean;
+  remarks?: string | null;
+};
+
+export type ExamMarksGrid = {
+  schedules: ExamSchedule[];
+  students: Array<{
+    studentUserId: string;
+    studentName: string;
+    studentCode?: string | null;
+  }>;
+  marks: ExamMark[];
+};
+
+export type ExamResult = {
+  id: string;
+  examId: string;
+  studentUserId: string;
+  studentName?: string | null;
+  studentCode?: string | null;
+  totalMaxMarks: number;
+  totalObtainedMarks: number;
+  percentage: number;
+  grade?: string | null;
+  rank?: number | null;
+  isPassed: boolean;
+  status: ResultStatus;
+  examName?: string | null;
+  className?: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ReportCard = {
+  exam: Exam;
+  studentUserId: string;
+  studentName: string;
+  studentCode?: string | null;
+  subjects: Array<{
+    subjectId: string;
+    subjectName: string;
+    maxMarks: number;
+    passMarks: number;
+    marksObtained?: number | null;
+    grade?: string | null;
+    isAbsent: boolean;
+    isPassed: boolean;
+    examDate?: string | null;
+  }>;
+  result?: ExamResult | null;
+};
+
+export type ClassReport = {
+  exam: Exam;
+  totalStudents: number;
+  resultsGenerated: number;
+  passCount: number;
+  failCount: number;
+  passPercentage: number;
+  classAveragePercentage: number;
+  subjects: Array<{
+    subjectId: string;
+    subjectName: string;
+    averageMarks: number;
+    averagePercentage: number;
+    passCount: number;
+    failCount: number;
+    absentCount: number;
+    highestMarks: number;
+    lowestMarks: number;
+  }>;
+};
+
+export type ExamDashboardStats = {
+  totalExams: number;
+  draftCount: number;
+  scheduledCount: number;
+  inProgressCount: number;
+  completedCount: number;
+  publishedCount: number;
+  pendingMarksCount: number;
+  upcomingSchedules: Array<{
+    scheduleId: string;
+    examId: string;
+    examName: string;
+    subjectName: string;
+    examDate: string;
+    startTime?: string | null;
+    className?: string | null;
+  }>;
+  recentExams: Exam[];
+};
+
+export type CreateExamPayload = {
+  name: string;
+  academicYear: string;
+  examType: ExamType;
+  classId: string;
+  startDate?: string;
+  endDate?: string;
+  description?: string;
+};
+
+export type CreateSchedulePayload = {
+  subjectId: string;
+  examDate: string;
+  startTime?: string;
+  endTime?: string;
+  maxMarks: number;
+  passMarks?: number;
+  venue?: string;
+};
+
+export type UpsertMarkItem = {
+  scheduleId: string;
+  studentUserId: string;
+  marksObtained?: number | null;
+  isAbsent?: boolean;
+  remarks?: string | null;
+};

--- a/src/modules/exams/utils/format.ts
+++ b/src/modules/exams/utils/format.ts
@@ -1,0 +1,49 @@
+import type { ExamStatus, ExamType } from "../types";
+
+export const EXAM_TYPE_LABELS: Record<ExamType, string> = {
+  UNIT_TEST: "Unit Test",
+  MIDTERM: "Midterm",
+  FINAL: "Final",
+  PRACTICAL: "Practical",
+  OTHER: "Other",
+};
+
+export const EXAM_STATUS_LABELS: Record<ExamStatus, string> = {
+  DRAFT: "Draft",
+  SCHEDULED: "Scheduled",
+  IN_PROGRESS: "In Progress",
+  COMPLETED: "Completed",
+  RESULTS_PUBLISHED: "Published",
+  CANCELLED: "Cancelled",
+};
+
+export function examStatusClass(status: ExamStatus): string {
+  switch (status) {
+    case "DRAFT":
+      return "bg-slate-100 text-slate-700";
+    case "SCHEDULED":
+      return "bg-blue-50 text-blue-700";
+    case "IN_PROGRESS":
+      return "bg-amber-50 text-amber-700";
+    case "COMPLETED":
+      return "bg-indigo-50 text-indigo-700";
+    case "RESULTS_PUBLISHED":
+      return "bg-green-50 text-green-700";
+    case "CANCELLED":
+      return "bg-red-50 text-red-700";
+    default:
+      return "bg-slate-100 text-slate-700";
+  }
+}
+
+export function formatClassLabel(
+  name?: string | null,
+  section?: string | null,
+): string {
+  if (!name) return "—";
+  return section ? `${name}-${section}` : name;
+}
+
+export function formatPercent(value: number): string {
+  return `${Number(value).toFixed(1)}%`;
+}


### PR DESCRIPTION
## Summary
- Adds admin Exams & Results UI: dashboard, exam list/create, schedule, marks entry, results generate/publish, report cards, and class reports.
- Adds student My Exams pages for published results and report cards.
- Wires navigation and `ADMIN_API` / `STUDENT_API` routes to the new examination backend.

## Test plan
- [ ] Open `/admin/exams` and confirm dashboard stats load
- [ ] Create an exam, add schedules, enter marks, generate and publish results
- [ ] Check report card and class report pages for a published exam
- [ ] As a student, open `/student/exams` and view a published report card
- [ ] Confirm nav links for Exams & Results and My Exams are correct on desktop and mobile


Made with [Cursor](https://cursor.com)