### PR TITLE
Add homework and assignment management UI

### DIFF
--- a/src/app/admin/homework/[homeworkId]/page.tsx
+++ b/src/app/admin/homework/[homeworkId]/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { HomeworkDetailView } from "@/modules/homework/components/HomeworkDetailView";
+
+export default function AdminHomeworkDetailPage({
+  params,
+}: {
+  params: Promise<{ homeworkId: string }>;
+}) {
+  return <HomeworkDetailView params={params} scope="admin" />;
+}

--- a/src/app/admin/homework/[homeworkId]/submissions/page.tsx
+++ b/src/app/admin/homework/[homeworkId]/submissions/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { HomeworkSubmissionsView } from "@/modules/homework/components/HomeworkSubmissionsView";
+
+export default function AdminHomeworkSubmissionsPage({
+  params,
+}: {
+  params: Promise<{ homeworkId: string }>;
+}) {
+  return <HomeworkSubmissionsView params={params} scope="admin" />;
+}

--- a/src/app/admin/homework/page.tsx
+++ b/src/app/admin/homework/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { HomeworkListPage } from "@/modules/homework";
+
+export default function AdminHomeworkPage() {
+  return <HomeworkListPage scope="admin" />;
+}

--- a/src/app/student/homework/[homeworkId]/page.tsx
+++ b/src/app/student/homework/[homeworkId]/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { use, useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  HOMEWORK_TYPE_LABELS,
+  HomeworkStatusBadge,
+  HomeworkSubnav,
+  SubmissionDialog,
+  SubmissionStatusBadge,
+  formatDueAt,
+  useStudentHomeworkDetail,
+  useSubmitHomeworkMutation,
+  type SubmitHomeworkPayload,
+} from "@/modules/homework";
+
+export default function StudentHomeworkDetailPage({
+  params,
+}: {
+  params: Promise<{ homeworkId: string }>;
+}) {
+  const { homeworkId } = use(params);
+  const { data, isLoading, isError } = useStudentHomeworkDetail(homeworkId);
+  const submitMutation = useSubmitHomeworkMutation();
+  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+
+  if (isLoading) {
+    return <div className="p-6 text-sm text-slate-600">Loading…</div>;
+  }
+  if (isError || !data) {
+    return <div className="p-6 text-sm text-red-600">Homework not found.</div>;
+  }
+
+  const allowedToSubmit =
+    data.status === "PUBLISHED" &&
+    data.mySubmission?.status !== "REVIEWED";
+
+  const onSubmit = async (payload: SubmitHomeworkPayload) => {
+    await submitMutation.mutateAsync({ homeworkId, payload });
+    toast({ title: "Submitted", type: "success" });
+  };
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-2 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-[24px] font-[600] text-[#021034]">{data.title}</h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            {HOMEWORK_TYPE_LABELS[data.type]} · Due {formatDueAt(data.dueAt)}
+          </p>
+        </div>
+        {allowedToSubmit ? (
+          <Button variant="dark" onClick={() => setOpen(true)}>
+            {data.mySubmission ? "Resubmit" : "Submit"}
+          </Button>
+        ) : null}
+      </div>
+
+      <HomeworkSubnav basePath="/student/homework" />
+
+      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+        <Card className="p-5">
+          <div className="mb-3 flex flex-wrap items-center gap-2">
+            <HomeworkStatusBadge status={data.status} />
+            {data.mySubmissionStatus ? (
+              <SubmissionStatusBadge status={data.mySubmissionStatus} />
+            ) : null}
+          </div>
+          <h2 className="mb-2 text-sm font-semibold text-[#021034]">
+            Instructions
+          </h2>
+          <p className="whitespace-pre-wrap text-sm text-slate-700">
+            {data.description || "No description provided."}
+          </p>
+          {data.attachments?.length ? (
+            <div className="mt-4">
+              <h3 className="mb-2 text-sm font-semibold text-[#021034]">
+                Attachments
+              </h3>
+              <ul className="space-y-1 text-sm">
+                {data.attachments.map((a, i) => (
+                  <li key={`${a.url}-${i}`}>
+                    <a
+                      href={a.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-blue-700 hover:underline"
+                    >
+                      {a.filename}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </Card>
+
+        <Card className="space-y-3 p-5 text-sm">
+          <div>
+            <div className="text-slate-500">Subject</div>
+            <div className="font-medium text-[#021034]">
+              {data.subjectName || "—"}
+            </div>
+          </div>
+          <div>
+            <div className="text-slate-500">Max marks</div>
+            <div className="font-medium text-[#021034]">
+              {data.maxMarks ?? "—"}
+            </div>
+          </div>
+          <div>
+            <div className="text-slate-500">Late submissions</div>
+            <div className="font-medium text-[#021034]">
+              {data.allowLateSubmission ? "Allowed" : "Not allowed"}
+            </div>
+          </div>
+        </Card>
+      </div>
+
+      <Card className="mt-4 p-5">
+        <h2 className="mb-3 text-sm font-semibold text-[#021034]">
+          My submission
+        </h2>
+        {!data.mySubmission ? (
+          <p className="text-sm text-slate-600">You have not submitted yet.</p>
+        ) : (
+          <div className="space-y-2 text-sm">
+            <div className="flex flex-wrap items-center gap-2">
+              <SubmissionStatusBadge status={data.mySubmission.status} />
+              {data.mySubmission.isLate ? (
+                <span className="text-xs text-orange-600">Late</span>
+              ) : null}
+              {data.mySubmission.submittedAt ? (
+                <span className="text-slate-500">
+                  {formatDueAt(data.mySubmission.submittedAt)}
+                </span>
+              ) : null}
+            </div>
+            <p className="whitespace-pre-wrap text-slate-700">
+              {data.mySubmission.content || "No text content."}
+            </p>
+            {data.mySubmission.attachments?.length ? (
+              <ul className="space-y-1">
+                {data.mySubmission.attachments.map((a, i) => (
+                  <li key={`${a.url}-${i}`}>
+                    <a
+                      href={a.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-blue-700 hover:underline"
+                    >
+                      {a.filename}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {(data.mySubmission.marksObtained != null ||
+              data.mySubmission.remarks) && (
+              <div className="rounded-md border border-[#E8EEF9] bg-[#F8FBFF] p-3">
+                <div>
+                  Marks:{" "}
+                  <span className="font-medium">
+                    {data.mySubmission.marksObtained ?? "—"}
+                  </span>
+                </div>
+                {data.mySubmission.remarks ? (
+                  <div className="mt-1 text-slate-700">
+                    Remarks: {data.mySubmission.remarks}
+                  </div>
+                ) : null}
+              </div>
+            )}
+          </div>
+        )}
+      </Card>
+
+      <SubmissionDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        onSubmit={onSubmit}
+        initialContent={data.mySubmission?.content}
+        initialAttachments={data.mySubmission?.attachments}
+      />
+    </div>
+  );
+}

--- a/src/app/student/homework/page.tsx
+++ b/src/app/student/homework/page.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import {
+  HOMEWORK_PAGE_SIZE,
+  HOMEWORK_TYPE_LABELS,
+  HomeworkStatusBadge,
+  HomeworkSubnav,
+  SubmissionStatusBadge,
+  formatDueAt,
+  isOverdue,
+  useStudentHomeworkList,
+  type HomeworkStatus,
+  type HomeworkType,
+} from "@/modules/homework";
+
+export default function StudentHomeworkPage() {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [type, setType] = useState<HomeworkType | "">("");
+  const [status, setStatus] = useState<HomeworkStatus | "">("");
+
+  const listQuery = useStudentHomeworkList({
+    page,
+    limit: HOMEWORK_PAGE_SIZE,
+    search: search.trim() || undefined,
+    type: type || undefined,
+    status: status || undefined,
+  });
+
+  const rows = listQuery.data?.data ?? [];
+  const total = listQuery.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / HOMEWORK_PAGE_SIZE));
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-2">
+        <h1 className="text-[24px] font-[600] text-[#021034]">My Homework</h1>
+        <p className="mt-1 text-[14px] text-[#737373]">
+          View assigned work, check due dates, and submit your answers.
+        </p>
+      </div>
+
+      <HomeworkSubnav basePath="/student/homework" />
+
+      <div className="mb-4 flex flex-wrap gap-2">
+        <Input
+          className="max-w-xs"
+          placeholder="Search…"
+          value={search}
+          onChange={(e) => {
+            setPage(1);
+            setSearch(e.target.value);
+          }}
+        />
+        <select
+          className="rounded-md border border-[#D7E3FC] px-3 py-2 text-sm"
+          value={type}
+          onChange={(e) => {
+            setPage(1);
+            setType(e.target.value as HomeworkType | "");
+          }}
+        >
+          <option value="">All types</option>
+          <option value="HOMEWORK">Homework</option>
+          <option value="ASSIGNMENT">Assignment</option>
+        </select>
+        <select
+          className="rounded-md border border-[#D7E3FC] px-3 py-2 text-sm"
+          value={status}
+          onChange={(e) => {
+            setPage(1);
+            setStatus(e.target.value as HomeworkStatus | "");
+          }}
+        >
+          <option value="">Open & closed</option>
+          <option value="PUBLISHED">Published</option>
+          <option value="CLOSED">Closed</option>
+        </select>
+      </div>
+
+      <div className="grid gap-3">
+        {listQuery.isLoading ? (
+          <Card className="p-5 text-sm text-slate-600">Loading…</Card>
+        ) : rows.length === 0 ? (
+          <Card className="p-5 text-sm text-slate-600">
+            No homework assigned yet.
+          </Card>
+        ) : (
+          rows.map((row) => (
+            <Card key={row.id} className="p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Link
+                      href={`/student/homework/${row.id}`}
+                      className="text-base font-semibold text-[#021034] hover:underline"
+                    >
+                      {row.title}
+                    </Link>
+                    <HomeworkStatusBadge status={row.status} />
+                    {row.mySubmissionStatus ? (
+                      <SubmissionStatusBadge status={row.mySubmissionStatus} />
+                    ) : null}
+                  </div>
+                  <p className="mt-1 text-sm text-slate-600">
+                    {HOMEWORK_TYPE_LABELS[row.type]}
+                    {row.subjectName ? ` · ${row.subjectName}` : ""}
+                    {" · Due "}
+                    {formatDueAt(row.dueAt)}
+                    {isOverdue(row.dueAt, row.status) ? (
+                      <span className="text-orange-600"> · Overdue</span>
+                    ) : null}
+                  </p>
+                </div>
+                <Link href={`/student/homework/${row.id}`}>
+                  <Button variant="dark">Open</Button>
+                </Link>
+              </div>
+            </Card>
+          ))
+        )}
+      </div>
+
+      <div className="mt-4 flex items-center justify-between text-sm text-slate-600">
+        <span>
+          Page {page} of {totalPages} · {total} total
+        </span>
+        <div className="flex gap-2">
+          <Button
+            variant="ghost"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="ghost"
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/teacher/homework/[homeworkId]/page.tsx
+++ b/src/app/teacher/homework/[homeworkId]/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { HomeworkDetailView } from "@/modules/homework/components/HomeworkDetailView";
+
+export default function TeacherHomeworkDetailPage({
+  params,
+}: {
+  params: Promise<{ homeworkId: string }>;
+}) {
+  return <HomeworkDetailView params={params} scope="teacher" />;
+}

--- a/src/app/teacher/homework/[homeworkId]/submissions/page.tsx
+++ b/src/app/teacher/homework/[homeworkId]/submissions/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { HomeworkSubmissionsView } from "@/modules/homework/components/HomeworkSubmissionsView";
+
+export default function TeacherHomeworkSubmissionsPage({
+  params,
+}: {
+  params: Promise<{ homeworkId: string }>;
+}) {
+  return <HomeworkSubmissionsView params={params} scope="teacher" />;
+}

--- a/src/app/teacher/homework/page.tsx
+++ b/src/app/teacher/homework/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { HomeworkListPage } from "@/modules/homework";
+
+export default function TeacherHomeworkPage() {
+  return <HomeworkListPage scope="teacher" />;
+}

--- a/src/components/layout/navConfig.ts
+++ b/src/components/layout/navConfig.ts
@@ -55,6 +55,11 @@ export const managementNav = [
     icon: BookOpen,
   },
   {
+    label: "Homework",
+    href: "/admin/homework",
+    icon: ClipboardCheck,
+  },
+  {
     label: "Reports & Analytics",
     href: "/admin/reports",
     icon: ClipboardList,
@@ -78,6 +83,11 @@ export const teacherNav = [
     icon: GraduationCap,
   },
   {
+    label: "Homework",
+    href: "/teacher/homework",
+    icon: ClipboardList,
+  },
+  {
     label: "Take Attendance",
     href: "/teacher/attendance",
     icon: ClipboardCheck,
@@ -99,6 +109,11 @@ export const studentNav = [
     label: "My Profile",
     href: "/student/profile",
     icon: GraduationCap,
+  },
+  {
+    label: "My Homework",
+    href: "/student/homework",
+    icon: ClipboardList,
   },
   {
     label: "My Exams",

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -33,6 +33,8 @@ export const ADMIN_API = {
   DOCUMENTS: "/admin/documents",
   DOCUMENTS_UPLOAD: "/admin/documents/upload",
   DOCUMENT_BY_ID: (id: string) => `/admin/documents/${id}`,
+  HOMEWORK: "/admin/homework",
+  HOMEWORK_BY_ID: (id: string) => `/admin/homework/${id}`,
   EXAMS_DASHBOARD: "/admin/exams/dashboard",
   EXAMS: "/admin/exams",
   EXAM_BY_ID: (id: string) => `/admin/exams/${id}`,
@@ -84,6 +86,8 @@ export const TEACHER_API = {
   DASHBOARD: "/teacher/dashboard",
   CLASS: "/teacher/class",
   PROFILE: (id: string) => `/admin/teachers/${id}`,
+  HOMEWORK: "/teacher/homework",
+  HOMEWORK_BY_ID: (id: string) => `/teacher/homework/${id}`,
 };
 
 export const ATTENDANCE_API = {
@@ -101,6 +105,9 @@ export const STUDENT_API = {
   BY_ID: (id: string) => `/admin/students/${id}`,
   /** Update student (admin or class teacher) */
   UPDATE: (id: string) => `/students/${id}`,
+  HOMEWORK: "/student/homework",
+  HOMEWORK_BY_ID: (id: string) => `/student/homework/${id}`,
+  HOMEWORK_SUBMIT: (id: string) => `/student/homework/${id}/submissions`,
   EXAMS: "/student/exams",
   EXAM_REPORT_CARD: (examId: string) => `/student/exams/${examId}/report-card`,
   FEES: "/student/fees",

--- a/src/modules/homework/api/homework.ts
+++ b/src/modules/homework/api/homework.ts
@@ -1,0 +1,151 @@
+import type { AxiosRequestConfig } from "axios";
+import { ADMIN_API, STUDENT_API, TEACHER_API } from "@/config/api-routes";
+import API from "@/services/axios";
+import type {
+  CreateHomeworkPayload,
+  Homework,
+  HomeworkQuery,
+  HomeworkSubmission,
+  Paginated,
+  ReviewSubmissionPayload,
+  StudentHomeworkDetail,
+  SubmissionQuery,
+  SubmitHomeworkPayload,
+  UpdateHomeworkPayload,
+} from "@/modules/homework/types";
+
+type RoleScope = "admin" | "teacher" | "student";
+
+function basePath(scope: RoleScope): string {
+  if (scope === "admin") return ADMIN_API.HOMEWORK;
+  if (scope === "teacher") return TEACHER_API.HOMEWORK;
+  return STUDENT_API.HOMEWORK;
+}
+
+function detailPath(scope: RoleScope, id: string): string {
+  if (scope === "admin") return ADMIN_API.HOMEWORK_BY_ID(id);
+  if (scope === "teacher") return TEACHER_API.HOMEWORK_BY_ID(id);
+  return STUDENT_API.HOMEWORK_BY_ID(id);
+}
+
+export async function fetchHomeworkList(
+  scope: "admin" | "teacher",
+  query: HomeworkQuery = {},
+  config?: AxiosRequestConfig,
+): Promise<Paginated<Homework>> {
+  const res = await API.get<Paginated<Homework>>(basePath(scope), {
+    params: query,
+    ...(config ?? {}),
+  });
+  return res.data;
+}
+
+export async function fetchStudentHomeworkList(
+  query: HomeworkQuery = {},
+  config?: AxiosRequestConfig,
+): Promise<Paginated<Homework>> {
+  const res = await API.get<Paginated<Homework>>(STUDENT_API.HOMEWORK, {
+    params: query,
+    ...(config ?? {}),
+  });
+  return res.data;
+}
+
+export async function fetchHomeworkDetail(
+  scope: "admin" | "teacher",
+  id: string,
+): Promise<Homework> {
+  const res = await API.get<Homework>(detailPath(scope, id));
+  return res.data;
+}
+
+export async function fetchStudentHomeworkDetail(
+  id: string,
+): Promise<StudentHomeworkDetail> {
+  const res = await API.get<StudentHomeworkDetail>(
+    STUDENT_API.HOMEWORK_BY_ID(id),
+  );
+  return res.data;
+}
+
+export async function createHomework(
+  scope: "admin" | "teacher",
+  payload: CreateHomeworkPayload,
+): Promise<Homework> {
+  const res = await API.post<Homework>(basePath(scope), payload);
+  return res.data;
+}
+
+export async function updateHomework(
+  scope: "admin" | "teacher",
+  id: string,
+  payload: UpdateHomeworkPayload,
+): Promise<Homework> {
+  const res = await API.patch<Homework>(detailPath(scope, id), payload);
+  return res.data;
+}
+
+export async function updateHomeworkStatus(
+  scope: "admin" | "teacher",
+  id: string,
+  status: "DRAFT" | "PUBLISHED" | "CLOSED",
+): Promise<Homework> {
+  const res = await API.patch<Homework>(
+    `${detailPath(scope, id)}/status`,
+    { status },
+  );
+  return res.data;
+}
+
+export async function deleteHomework(
+  scope: "admin" | "teacher",
+  id: string,
+): Promise<{ success: boolean }> {
+  const res = await API.delete<{ success: boolean }>(detailPath(scope, id));
+  return res.data;
+}
+
+export async function replaceHomeworkClasses(
+  scope: "admin" | "teacher",
+  id: string,
+  classIds: string[],
+) {
+  const res = await API.put(`${detailPath(scope, id)}/classes`, { classIds });
+  return res.data;
+}
+
+export async function fetchSubmissions(
+  scope: "admin" | "teacher",
+  homeworkId: string,
+  query: SubmissionQuery = {},
+): Promise<Paginated<HomeworkSubmission>> {
+  const res = await API.get<Paginated<HomeworkSubmission>>(
+    `${detailPath(scope, homeworkId)}/submissions`,
+    { params: query },
+  );
+  return res.data;
+}
+
+export async function reviewSubmission(
+  scope: "admin" | "teacher",
+  homeworkId: string,
+  submissionId: string,
+  payload: ReviewSubmissionPayload,
+): Promise<HomeworkSubmission> {
+  const res = await API.patch<HomeworkSubmission>(
+    `${detailPath(scope, homeworkId)}/submissions/${submissionId}/review`,
+    payload,
+  );
+  return res.data;
+}
+
+export async function submitHomework(
+  homeworkId: string,
+  payload: SubmitHomeworkPayload,
+): Promise<HomeworkSubmission> {
+  const res = await API.post<HomeworkSubmission>(
+    STUDENT_API.HOMEWORK_SUBMIT(homeworkId),
+    payload,
+  );
+  return res.data;
+}

--- a/src/modules/homework/components/HomeworkDetailView.tsx
+++ b/src/modules/homework/components/HomeworkDetailView.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { use, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  HomeworkStatusBadge,
+  HomeworkSubnav,
+  HOMEWORK_TYPE_LABELS,
+  formatDueAt,
+  useHomeworkDetail,
+  useHomeworkMutations,
+} from "@/modules/homework";
+
+type Props = {
+  params: Promise<{ homeworkId: string }>;
+  scope: "admin" | "teacher";
+};
+
+export function HomeworkDetailView({ params, scope }: Props) {
+  const { homeworkId } = use(params);
+  const basePath = scope === "admin" ? "/admin/homework" : "/teacher/homework";
+  const { data, isLoading, isError } = useHomeworkDetail(scope, homeworkId);
+  const mutations = useHomeworkMutations(scope);
+  const { toast } = useToast();
+  const [busy, setBusy] = useState(false);
+
+  if (isLoading) {
+    return <div className="p-6 text-sm text-slate-600">Loading…</div>;
+  }
+  if (isError || !data) {
+    return <div className="p-6 text-sm text-red-600">Homework not found.</div>;
+  }
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-2 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-[24px] font-[600] text-[#021034]">{data.title}</h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            {HOMEWORK_TYPE_LABELS[data.type]} · Due {formatDueAt(data.dueAt)}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link href={`${basePath}/${homeworkId}/submissions`}>
+            <Button variant="dark">View submissions</Button>
+          </Link>
+          {data.status === "DRAFT" && (
+            <Button
+              variant="ghost"
+              disabled={busy}
+              onClick={async () => {
+                setBusy(true);
+                try {
+                  await mutations.setStatus.mutateAsync({
+                    id: homeworkId,
+                    status: "PUBLISHED",
+                  });
+                  toast({ title: "Published", type: "success" });
+                } finally {
+                  setBusy(false);
+                }
+              }}
+            >
+              Publish
+            </Button>
+          )}
+          {data.status === "PUBLISHED" && (
+            <Button
+              variant="ghost"
+              disabled={busy}
+              onClick={async () => {
+                setBusy(true);
+                try {
+                  await mutations.setStatus.mutateAsync({
+                    id: homeworkId,
+                    status: "CLOSED",
+                  });
+                  toast({ title: "Closed", type: "success" });
+                } finally {
+                  setBusy(false);
+                }
+              }}
+            >
+              Close
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <HomeworkSubnav basePath={basePath} homeworkId={homeworkId} />
+
+      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+        <Card className="p-5">
+          <div className="mb-3 flex items-center gap-2">
+            <HomeworkStatusBadge status={data.status} />
+            {data.allowLateSubmission ? (
+              <span className="text-xs text-slate-500">Late allowed</span>
+            ) : (
+              <span className="text-xs text-slate-500">No late submissions</span>
+            )}
+          </div>
+          <h2 className="mb-2 text-sm font-semibold text-[#021034]">
+            Instructions
+          </h2>
+          <p className="whitespace-pre-wrap text-sm text-slate-700">
+            {data.description || "No description provided."}
+          </p>
+
+          {data.attachments?.length ? (
+            <div className="mt-4">
+              <h3 className="mb-2 text-sm font-semibold text-[#021034]">
+                Attachments
+              </h3>
+              <ul className="space-y-1 text-sm">
+                {data.attachments.map((a, i) => (
+                  <li key={`${a.url}-${i}`}>
+                    <a
+                      href={a.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-blue-700 hover:underline"
+                    >
+                      {a.filename}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </Card>
+
+        <Card className="space-y-3 p-5 text-sm">
+          <div>
+            <div className="text-slate-500">Subject</div>
+            <div className="font-medium text-[#021034]">
+              {data.subjectName || "—"}
+            </div>
+          </div>
+          <div>
+            <div className="text-slate-500">Max marks</div>
+            <div className="font-medium text-[#021034]">
+              {data.maxMarks ?? "—"}
+            </div>
+          </div>
+          <div>
+            <div className="text-slate-500">Classes</div>
+            <div className="font-medium text-[#021034]">
+              {data.classes
+                .map(
+                  (c) => `${c.className}${c.section ? `-${c.section}` : ""}`,
+                )
+                .join(", ") || "—"}
+            </div>
+          </div>
+          <div>
+            <div className="text-slate-500">Created by</div>
+            <div className="font-medium text-[#021034]">
+              {data.createdByName || "—"}
+            </div>
+          </div>
+          <div>
+            <div className="text-slate-500">Submissions</div>
+            <div className="font-medium text-[#021034]">
+              {data.submissionCount ?? 0} total · {data.reviewedCount ?? 0}{" "}
+              reviewed
+            </div>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/homework/components/HomeworkDialog.tsx
+++ b/src/modules/homework/components/HomeworkDialog.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useForm, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import axios from "axios";
+import { Button } from "@/components/ui/Button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/Form";
+import { Input } from "@/components/ui/Input";
+import { Textarea } from "@/components/ui/Textarea";
+import MultiSelect from "@/components/ui/MultiSelect";
+import {
+  createHomeworkSchema,
+  type CreateHomeworkValues,
+} from "@/modules/homework/schemas/homework.schemas";
+import type { CreateHomeworkPayload, Homework } from "@/modules/homework/types";
+
+type Option = { id: string; name: string };
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (payload: CreateHomeworkPayload) => Promise<void>;
+  classOptions: Option[];
+  subjectOptions: Option[];
+  initial?: Homework | null;
+  title?: string;
+};
+
+function toLocalInputValue(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function HomeworkDialog({
+  open,
+  onClose,
+  onSubmit,
+  classOptions,
+  subjectOptions,
+  initial = null,
+  title,
+}: Props) {
+  const [attachments, setAttachments] = useState<
+    { filename: string; url: string }[]
+  >([]);
+  const form = useForm<CreateHomeworkValues>({
+    resolver: zodResolver(
+      createHomeworkSchema,
+    ) as unknown as Resolver<CreateHomeworkValues>,
+    mode: "onChange",
+    defaultValues: {
+      title: "",
+      description: "",
+      type: "HOMEWORK",
+      subjectId: "",
+      dueAt: "",
+      allowLateSubmission: true,
+      classIds: [],
+    },
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    if (initial) {
+      form.reset({
+        title: initial.title,
+        description: initial.description ?? "",
+        type: initial.type,
+        subjectId: initial.subjectId ?? "",
+        dueAt: toLocalInputValue(initial.dueAt),
+        maxMarks: initial.maxMarks ?? undefined,
+        allowLateSubmission: initial.allowLateSubmission,
+        classIds: initial.classes.map((c) => c.classId),
+      });
+      setAttachments(initial.attachments ?? []);
+    } else {
+      form.reset({
+        title: "",
+        description: "",
+        type: "HOMEWORK",
+        subjectId: "",
+        dueAt: "",
+        allowLateSubmission: true,
+        classIds: [],
+      });
+      setAttachments([]);
+    }
+  }, [open, initial, form]);
+
+  if (!open) return null;
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    try {
+      const payload: CreateHomeworkPayload = {
+        title: values.title.trim(),
+        description: values.description?.trim() || undefined,
+        type: values.type,
+        subjectId: values.subjectId || undefined,
+        dueAt: new Date(values.dueAt).toISOString(),
+        maxMarks:
+          values.maxMarks === undefined || Number.isNaN(values.maxMarks)
+            ? undefined
+            : values.maxMarks,
+        allowLateSubmission: values.allowLateSubmission,
+        classIds: values.classIds,
+        attachments: attachments.filter((a) => a.filename && a.url),
+      };
+      await onSubmit(payload);
+      onClose();
+    } catch (err) {
+      const message = axios.isAxiosError(err)
+        ? (err.response?.data as { message?: string | string[] })?.message
+        : null;
+      form.setError("root", {
+        message: Array.isArray(message)
+          ? message.join(", ")
+          : message || "Failed to save homework",
+      });
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/40 p-4">
+      <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg bg-white p-5 shadow-xl">
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-[#021034]">
+              {title ?? (initial ? "Edit work" : "Create homework / assignment")}
+            </h2>
+            <p className="mt-1 text-sm text-slate-600">
+              Assign to one or more classes with a due date and attachments.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="text-slate-500"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <Form onSubmit={handleSubmit} className="space-y-4">
+          <FormField>
+            <FormLabel>Title</FormLabel>
+            <FormControl>
+              <Input {...form.register("title")} placeholder="Title" />
+            </FormControl>
+            <FormMessage>{form.formState.errors.title?.message}</FormMessage>
+          </FormField>
+
+          <FormField>
+            <FormLabel>Type</FormLabel>
+            <FormControl>
+              <select
+                className="w-full rounded-md border border-[#D7E3FC] px-3 py-2 text-sm"
+                {...form.register("type")}
+              >
+                <option value="HOMEWORK">Homework</option>
+                <option value="ASSIGNMENT">Assignment</option>
+              </select>
+            </FormControl>
+          </FormField>
+
+          <FormField>
+            <FormLabel>Description</FormLabel>
+            <FormControl>
+              <Textarea
+                rows={4}
+                {...form.register("description")}
+                placeholder="Instructions for students"
+              />
+            </FormControl>
+          </FormField>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField>
+              <FormLabel>Due date</FormLabel>
+              <FormControl>
+                <Input type="datetime-local" {...form.register("dueAt")} />
+              </FormControl>
+              <FormMessage>{form.formState.errors.dueAt?.message}</FormMessage>
+            </FormField>
+            <FormField>
+              <FormLabel>Max marks (optional)</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  step="0.01"
+                  min={0}
+                  {...form.register("maxMarks")}
+                />
+              </FormControl>
+            </FormField>
+          </div>
+
+          <FormField>
+            <FormLabel>Subject (optional)</FormLabel>
+            <FormControl>
+              <select
+                className="w-full rounded-md border border-[#D7E3FC] px-3 py-2 text-sm"
+                {...form.register("subjectId")}
+              >
+                <option value="">No subject</option>
+                {subjectOptions.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name}
+                  </option>
+                ))}
+              </select>
+            </FormControl>
+          </FormField>
+
+          <FormField>
+            <FormLabel>Classes</FormLabel>
+            <FormControl>
+              <MultiSelect
+                options={classOptions}
+                value={form.watch("classIds")}
+                onChange={(ids) =>
+                  form.setValue("classIds", ids, { shouldValidate: true })
+                }
+                placeholder="Select classes"
+              />
+            </FormControl>
+            <FormMessage>{form.formState.errors.classIds?.message}</FormMessage>
+          </FormField>
+
+          <label className="flex items-center gap-2 text-sm text-slate-700">
+            <input type="checkbox" {...form.register("allowLateSubmission")} />
+            Allow late submission
+          </label>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <FormLabel>Attachments</FormLabel>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() =>
+                  setAttachments((prev) => [...prev, { filename: "", url: "" }])
+                }
+              >
+                + Add file URL
+              </Button>
+            </div>
+            {attachments.map((a, idx) => (
+              <div key={idx} className="grid gap-2 sm:grid-cols-[1fr_2fr_auto]">
+                <Input
+                  placeholder="Filename"
+                  value={a.filename}
+                  onChange={(e) =>
+                    setAttachments((prev) =>
+                      prev.map((item, i) =>
+                        i === idx ? { ...item, filename: e.target.value } : item,
+                      ),
+                    )
+                  }
+                />
+                <Input
+                  placeholder="https://..."
+                  value={a.url}
+                  onChange={(e) =>
+                    setAttachments((prev) =>
+                      prev.map((item, i) =>
+                        i === idx ? { ...item, url: e.target.value } : item,
+                      ),
+                    )
+                  }
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() =>
+                    setAttachments((prev) => prev.filter((_, i) => i !== idx))
+                  }
+                >
+                  Remove
+                </Button>
+              </div>
+            ))}
+          </div>
+
+          {form.formState.errors.root?.message && (
+            <p className="text-sm text-red-600">
+              {form.formState.errors.root.message}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="dark"
+              disabled={form.formState.isSubmitting}
+            >
+              {form.formState.isSubmitting ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/homework/components/HomeworkListPage.tsx
+++ b/src/modules/homework/components/HomeworkListPage.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import { useToast } from "@/components/ui/use-toast";
+import { fetchClasses } from "@/modules/classes/api/classes";
+import { fetchSubjects } from "@/modules/subjects/api/subjects";
+import { getTeacherDashboard } from "@/modules/teachers/api/portal";
+import {
+  HomeworkDialog,
+  HomeworkStatusBadge,
+  HomeworkSubnav,
+  HOMEWORK_PAGE_SIZE,
+  HOMEWORK_TYPE_LABELS,
+  formatDueAt,
+  useHomeworkList,
+  useHomeworkMutations,
+  type CreateHomeworkPayload,
+  type Homework,
+  type HomeworkStatus,
+  type HomeworkType,
+} from "@/modules/homework";
+
+type Scope = "admin" | "teacher";
+
+export function HomeworkListPage({ scope }: { scope: Scope }) {
+  const basePath = scope === "admin" ? "/admin/homework" : "/teacher/homework";
+  const { toast } = useToast();
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [type, setType] = useState<HomeworkType | "">("");
+  const [status, setStatus] = useState<HomeworkStatus | "">("");
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<Homework | null>(null);
+
+  const query = {
+    page,
+    limit: HOMEWORK_PAGE_SIZE,
+    search: search.trim() || undefined,
+    type: type || undefined,
+    status: status || undefined,
+  };
+
+  const listQuery = useHomeworkList(scope, query);
+  const mutations = useHomeworkMutations(scope);
+
+  const optionsQuery = useQuery({
+    queryKey: ["homework-form-options", scope],
+    queryFn: async () => {
+      if (scope === "admin") {
+        const [classesRes, subjectsRes] = await Promise.all([
+          fetchClasses({ page: 1, pageSize: 200 }),
+          fetchSubjects({ page: 1, pageSize: 200 }),
+        ]);
+        return {
+          classes: (classesRes.classes ?? []).map((c) => ({
+            id: c.id,
+            name: `${c.name}${c.section ? `-${c.section}` : ""}`,
+          })),
+          subjects: (subjectsRes.subjects ?? []).map((s) => ({
+            id: s.id,
+            name: s.name,
+          })),
+        };
+      }
+
+      const dashboard = await getTeacherDashboard();
+      const classMap = new Map<string, string>();
+      if (dashboard.assignedClass?.classId) {
+        classMap.set(
+          dashboard.assignedClass.classId,
+          `${dashboard.assignedClass.class}${
+            dashboard.assignedClass.section
+              ? `-${dashboard.assignedClass.section}`
+              : ""
+          }`,
+        );
+      }
+      for (const s of dashboard.assignedSubjects) {
+        if (s.classId) {
+          classMap.set(
+            s.classId,
+            `${s.class}${s.section ? `-${s.section}` : ""}`,
+          );
+        }
+      }
+      const subjectMap = new Map<string, string>();
+      for (const s of dashboard.assignedSubjects) {
+        if (s.subjectId) subjectMap.set(s.subjectId, s.subject);
+      }
+      return {
+        classes: [...classMap.entries()].map(([id, name]) => ({ id, name })),
+        subjects: [...subjectMap.entries()].map(([id, name]) => ({
+          id,
+          name,
+        })),
+      };
+    },
+  });
+
+  const rows = listQuery.data?.data ?? [];
+  const total = listQuery.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / HOMEWORK_PAGE_SIZE));
+
+  const classOptions = useMemo(
+    () => optionsQuery.data?.classes ?? [],
+    [optionsQuery.data],
+  );
+  const subjectOptions = useMemo(
+    () => optionsQuery.data?.subjects ?? [],
+    [optionsQuery.data],
+  );
+
+  const save = async (payload: CreateHomeworkPayload) => {
+    if (editing) {
+      await mutations.update.mutateAsync({ id: editing.id, payload });
+      toast({ title: "Updated", type: "success" });
+    } else {
+      await mutations.create.mutateAsync(payload);
+      toast({ title: "Created", type: "success" });
+    }
+    setEditing(null);
+  };
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-[24px] font-[600] text-[#021034]">
+            Homework & Assignments
+          </h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            Create work, assign classes, track submissions and reviews.
+          </p>
+        </div>
+        <Button
+          variant="dark"
+          onClick={() => {
+            setEditing(null);
+            setDialogOpen(true);
+          }}
+        >
+          + Create
+        </Button>
+      </div>
+
+      <HomeworkSubnav basePath={basePath} />
+
+      <div className="mb-4 flex flex-wrap gap-2">
+        <Input
+          className="max-w-xs"
+          placeholder="Search…"
+          value={search}
+          onChange={(e) => {
+            setPage(1);
+            setSearch(e.target.value);
+          }}
+        />
+        <select
+          className="rounded-md border border-[#D7E3FC] px-3 py-2 text-sm"
+          value={type}
+          onChange={(e) => {
+            setPage(1);
+            setType(e.target.value as HomeworkType | "");
+          }}
+        >
+          <option value="">All types</option>
+          <option value="HOMEWORK">Homework</option>
+          <option value="ASSIGNMENT">Assignment</option>
+        </select>
+        <select
+          className="rounded-md border border-[#D7E3FC] px-3 py-2 text-sm"
+          value={status}
+          onChange={(e) => {
+            setPage(1);
+            setStatus(e.target.value as HomeworkStatus | "");
+          }}
+        >
+          <option value="">All statuses</option>
+          <option value="DRAFT">Draft</option>
+          <option value="PUBLISHED">Published</option>
+          <option value="CLOSED">Closed</option>
+        </select>
+      </div>
+
+      <Card className="overflow-x-auto p-0">
+        {listQuery.isLoading ? (
+          <div className="p-6 text-sm text-slate-600">Loading…</div>
+        ) : listQuery.isError ? (
+          <div className="p-6 text-sm text-red-600">Failed to load homework.</div>
+        ) : rows.length === 0 ? (
+          <div className="p-6 text-sm text-slate-600">No homework found.</div>
+        ) : (
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b border-[#E8EEF9] bg-[#F8FBFF] text-[#64748B]">
+              <tr>
+                <th className="px-4 py-3 font-medium">Title</th>
+                <th className="px-4 py-3 font-medium">Type</th>
+                <th className="px-4 py-3 font-medium">Due</th>
+                <th className="px-4 py-3 font-medium">Classes</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id} className="border-b border-[#F1F5F9]">
+                  <td className="px-4 py-3">
+                    <Link
+                      href={`${basePath}/${row.id}`}
+                      className="font-medium text-[#021034] hover:underline"
+                    >
+                      {row.title}
+                    </Link>
+                    {row.subjectName ? (
+                      <div className="text-xs text-slate-500">
+                        {row.subjectName}
+                      </div>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-3">
+                    {HOMEWORK_TYPE_LABELS[row.type]}
+                  </td>
+                  <td className="px-4 py-3">{formatDueAt(row.dueAt)}</td>
+                  <td className="px-4 py-3">
+                    {row.classes
+                      .map(
+                        (c) =>
+                          `${c.className}${c.section ? `-${c.section}` : ""}`,
+                      )
+                      .join(", ") || "—"}
+                  </td>
+                  <td className="px-4 py-3">
+                    <HomeworkStatusBadge status={row.status} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        variant="ghost"
+                        onClick={() => {
+                          setEditing(row);
+                          setDialogOpen(true);
+                        }}
+                      >
+                        Edit
+                      </Button>
+                      {row.status === "DRAFT" && (
+                        <Button
+                          variant="ghost"
+                          onClick={async () => {
+                            await mutations.setStatus.mutateAsync({
+                              id: row.id,
+                              status: "PUBLISHED",
+                            });
+                            toast({ title: "Published", type: "success" });
+                          }}
+                        >
+                          Publish
+                        </Button>
+                      )}
+                      {row.status === "PUBLISHED" && (
+                        <Button
+                          variant="ghost"
+                          onClick={async () => {
+                            await mutations.setStatus.mutateAsync({
+                              id: row.id,
+                              status: "CLOSED",
+                            });
+                            toast({ title: "Closed", type: "success" });
+                          }}
+                        >
+                          Close
+                        </Button>
+                      )}
+                      <Link href={`${basePath}/${row.id}/submissions`}>
+                        <Button variant="ghost">Submissions</Button>
+                      </Link>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Card>
+
+      <div className="mt-4 flex items-center justify-between text-sm text-slate-600">
+        <span>
+          Page {page} of {totalPages} · {total} total
+        </span>
+        <div className="flex gap-2">
+          <Button
+            variant="ghost"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="ghost"
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+
+      <HomeworkDialog
+        open={dialogOpen}
+        onClose={() => {
+          setDialogOpen(false);
+          setEditing(null);
+        }}
+        onSubmit={save}
+        classOptions={classOptions}
+        subjectOptions={subjectOptions}
+        initial={editing}
+      />
+    </div>
+  );
+}

--- a/src/modules/homework/components/HomeworkStatusBadge.tsx
+++ b/src/modules/homework/components/HomeworkStatusBadge.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import {
+  HOMEWORK_STATUS_LABELS,
+  SUBMISSION_STATUS_LABELS,
+  homeworkStatusClass,
+  submissionStatusClass,
+} from "@/modules/homework/utils/format";
+import type { HomeworkStatus, SubmissionStatus } from "@/modules/homework/types";
+
+export function HomeworkStatusBadge({ status }: { status: HomeworkStatus }) {
+  return (
+    <span className={homeworkStatusClass(status)}>
+      {HOMEWORK_STATUS_LABELS[status]}
+    </span>
+  );
+}
+
+export function SubmissionStatusBadge({
+  status,
+}: {
+  status: SubmissionStatus;
+}) {
+  return (
+    <span className={submissionStatusClass(status)}>
+      {SUBMISSION_STATUS_LABELS[status]}
+    </span>
+  );
+}

--- a/src/modules/homework/components/HomeworkSubmissionsView.tsx
+++ b/src/modules/homework/components/HomeworkSubmissionsView.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { use, useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  HomeworkSubnav,
+  ReviewDialog,
+  SubmissionStatusBadge,
+  formatDueAt,
+  useHomeworkDetail,
+  useHomeworkMutations,
+  useHomeworkSubmissions,
+  type HomeworkSubmission,
+  type ReviewSubmissionPayload,
+  type SubmissionStatus,
+} from "@/modules/homework";
+
+type Props = {
+  params: Promise<{ homeworkId: string }>;
+  scope: "admin" | "teacher";
+};
+
+export function HomeworkSubmissionsView({ params, scope }: Props) {
+  const { homeworkId } = use(params);
+  const basePath = scope === "admin" ? "/admin/homework" : "/teacher/homework";
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [status, setStatus] = useState<SubmissionStatus | "">("");
+  const [reviewing, setReviewing] = useState<HomeworkSubmission | null>(null);
+  const { toast } = useToast();
+
+  const detail = useHomeworkDetail(scope, homeworkId);
+  const submissions = useHomeworkSubmissions(scope, homeworkId, {
+    page,
+    limit: 20,
+    search: search.trim() || undefined,
+    status: status || undefined,
+  });
+  const mutations = useHomeworkMutations(scope);
+
+  const rows = submissions.data?.data ?? [];
+  const total = submissions.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / 20));
+
+  const onReview = async (payload: ReviewSubmissionPayload) => {
+    if (!reviewing) return;
+    await mutations.review.mutateAsync({
+      homeworkId,
+      submissionId: reviewing.id,
+      payload,
+    });
+    toast({ title: "Review saved", type: "success" });
+  };
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-2">
+        <h1 className="text-[24px] font-[600] text-[#021034]">
+          {detail.data?.title ?? "Submissions"}
+        </h1>
+        <p className="mt-1 text-[14px] text-[#737373]">
+          Review student work, assign marks, and leave remarks.
+        </p>
+      </div>
+
+      <HomeworkSubnav basePath={basePath} homeworkId={homeworkId} />
+
+      <div className="mb-4 flex flex-wrap gap-2">
+        <Input
+          className="max-w-xs"
+          placeholder="Search student…"
+          value={search}
+          onChange={(e) => {
+            setPage(1);
+            setSearch(e.target.value);
+          }}
+        />
+        <select
+          className="rounded-md border border-[#D7E3FC] px-3 py-2 text-sm"
+          value={status}
+          onChange={(e) => {
+            setPage(1);
+            setStatus(e.target.value as SubmissionStatus | "");
+          }}
+        >
+          <option value="">All statuses</option>
+          <option value="SUBMITTED">Submitted</option>
+          <option value="LATE">Late</option>
+          <option value="REVIEWED">Reviewed</option>
+          <option value="RETURNED">Returned</option>
+        </select>
+      </div>
+
+      <Card className="overflow-x-auto p-0">
+        {submissions.isLoading ? (
+          <div className="p-6 text-sm text-slate-600">Loading…</div>
+        ) : rows.length === 0 ? (
+          <div className="p-6 text-sm text-slate-600">No submissions yet.</div>
+        ) : (
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b border-[#E8EEF9] bg-[#F8FBFF] text-[#64748B]">
+              <tr>
+                <th className="px-4 py-3 font-medium">Student</th>
+                <th className="px-4 py-3 font-medium">Class</th>
+                <th className="px-4 py-3 font-medium">Submitted</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Marks</th>
+                <th className="px-4 py-3 font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id} className="border-b border-[#F1F5F9] align-top">
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-[#021034]">
+                      {row.studentName || "—"}
+                    </div>
+                    {row.content ? (
+                      <p className="mt-1 line-clamp-2 text-xs text-slate-500">
+                        {row.content}
+                      </p>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-3">{row.className || "—"}</td>
+                  <td className="px-4 py-3">
+                    {row.submittedAt ? formatDueAt(row.submittedAt) : "—"}
+                    {row.isLate ? (
+                      <div className="text-xs text-orange-600">Late</div>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-3">
+                    <SubmissionStatusBadge status={row.status} />
+                  </td>
+                  <td className="px-4 py-3">
+                    {row.marksObtained ?? "—"}
+                    {row.remarks ? (
+                      <div className="mt-1 text-xs text-slate-500">
+                        {row.remarks}
+                      </div>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-3">
+                    {(row.status === "SUBMITTED" ||
+                      row.status === "LATE" ||
+                      row.status === "RETURNED" ||
+                      row.status === "REVIEWED") && (
+                      <Button variant="ghost" onClick={() => setReviewing(row)}>
+                        Review
+                      </Button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Card>
+
+      <div className="mt-4 flex items-center justify-between text-sm text-slate-600">
+        <span>
+          Page {page} of {totalPages} · {total} total
+        </span>
+        <div className="flex gap-2">
+          <Button
+            variant="ghost"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="ghost"
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+
+      <ReviewDialog
+        open={Boolean(reviewing)}
+        submission={reviewing}
+        maxMarks={detail.data?.maxMarks}
+        onClose={() => setReviewing(null)}
+        onSubmit={onReview}
+      />
+    </div>
+  );
+}

--- a/src/modules/homework/components/HomeworkSubnav.tsx
+++ b/src/modules/homework/components/HomeworkSubnav.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+type Props = {
+  basePath: "/teacher/homework" | "/admin/homework" | "/student/homework";
+  homeworkId?: string;
+  showSubmissions?: boolean;
+};
+
+export function HomeworkSubnav({
+  basePath,
+  homeworkId,
+  showSubmissions = true,
+}: Props) {
+  const pathname = usePathname();
+
+  const links: { href: string; label: string; exact?: boolean }[] = [
+    { href: basePath, label: "All work", exact: true },
+  ];
+
+  if (homeworkId && basePath !== "/student/homework") {
+    links.push({ href: `${basePath}/${homeworkId}`, label: "Details" });
+    if (showSubmissions) {
+      links.push({
+        href: `${basePath}/${homeworkId}/submissions`,
+        label: "Submissions",
+      });
+    }
+  }
+
+  return (
+    <div className="mb-4 flex flex-wrap gap-2">
+      {links.map((link) => {
+        const active = link.exact
+          ? pathname === link.href
+          : pathname === link.href || pathname.startsWith(`${link.href}/`);
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={
+              active
+                ? "rounded-md bg-[#DBEAFE] px-3 py-1.5 text-sm font-medium text-[#021034]"
+                : "rounded-md border border-[#D7E3FC] bg-white px-3 py-1.5 text-sm text-[#64748B]"
+            }
+          >
+            {link.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/modules/homework/components/ReviewDialog.tsx
+++ b/src/modules/homework/components/ReviewDialog.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import axios from "axios";
+import { Button } from "@/components/ui/Button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/Form";
+import { Input } from "@/components/ui/Input";
+import { Textarea } from "@/components/ui/Textarea";
+import {
+  reviewSubmissionSchema,
+  type ReviewSubmissionValues,
+} from "@/modules/homework/schemas/homework.schemas";
+import type {
+  HomeworkSubmission,
+  ReviewSubmissionPayload,
+} from "@/modules/homework/types";
+
+type Props = {
+  open: boolean;
+  submission: HomeworkSubmission | null;
+  maxMarks?: number | null;
+  onClose: () => void;
+  onSubmit: (payload: ReviewSubmissionPayload) => Promise<void>;
+};
+
+export function ReviewDialog({
+  open,
+  submission,
+  maxMarks,
+  onClose,
+  onSubmit,
+}: Props) {
+  const form = useForm<ReviewSubmissionValues>({
+    resolver: zodResolver(
+      reviewSubmissionSchema,
+    ) as unknown as Resolver<ReviewSubmissionValues>,
+    defaultValues: {
+      marksObtained: undefined,
+      remarks: "",
+      status: "REVIEWED",
+    },
+  });
+
+  useEffect(() => {
+    if (!open || !submission) return;
+    form.reset({
+      marksObtained: submission.marksObtained ?? undefined,
+      remarks: submission.remarks ?? "",
+      status: "REVIEWED",
+    });
+  }, [open, submission, form]);
+
+  if (!open || !submission) return null;
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    try {
+      await onSubmit({
+        marksObtained:
+          values.marksObtained === undefined ||
+          Number.isNaN(values.marksObtained)
+            ? undefined
+            : values.marksObtained,
+        remarks: values.remarks?.trim() || undefined,
+        status: values.status,
+      });
+      onClose();
+    } catch (err) {
+      const message = axios.isAxiosError(err)
+        ? (err.response?.data as { message?: string | string[] })?.message
+        : null;
+      form.setError("root", {
+        message: Array.isArray(message)
+          ? message.join(", ")
+          : message || "Review failed",
+      });
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-lg rounded-lg bg-white p-5 shadow-xl">
+        <h2 className="text-lg font-semibold text-[#021034]">
+          Review submission
+        </h2>
+        <p className="mt-1 text-sm text-slate-600">
+          {submission.studentName ?? "Student"}
+          {maxMarks != null ? ` · Max ${maxMarks}` : ""}
+        </p>
+
+        <Form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          <FormField>
+            <FormLabel>Marks</FormLabel>
+            <FormControl>
+              <Input
+                type="number"
+                step="0.01"
+                min={0}
+                max={maxMarks ?? undefined}
+                {...form.register("marksObtained")}
+              />
+            </FormControl>
+            <FormMessage>
+              {form.formState.errors.marksObtained?.message}
+            </FormMessage>
+          </FormField>
+
+          <FormField>
+            <FormLabel>Remarks</FormLabel>
+            <FormControl>
+              <Textarea rows={3} {...form.register("remarks")} />
+            </FormControl>
+          </FormField>
+
+          <FormField>
+            <FormLabel>Status</FormLabel>
+            <FormControl>
+              <select
+                className="w-full rounded-md border border-[#D7E3FC] px-3 py-2 text-sm"
+                {...form.register("status")}
+              >
+                <option value="REVIEWED">Reviewed</option>
+                <option value="RETURNED">Returned for resubmission</option>
+              </select>
+            </FormControl>
+          </FormField>
+
+          {form.formState.errors.root?.message && (
+            <p className="text-sm text-red-600">
+              {form.formState.errors.root.message}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="dark"
+              disabled={form.formState.isSubmitting}
+            >
+              {form.formState.isSubmitting ? "Saving…" : "Save review"}
+            </Button>
+          </div>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/homework/components/SubmissionDialog.tsx
+++ b/src/modules/homework/components/SubmissionDialog.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useForm, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import axios from "axios";
+import { Button } from "@/components/ui/Button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/Form";
+import { Input } from "@/components/ui/Input";
+import { Textarea } from "@/components/ui/Textarea";
+import {
+  submitHomeworkSchema,
+  type SubmitHomeworkValues,
+} from "@/modules/homework/schemas/homework.schemas";
+import type { SubmitHomeworkPayload } from "@/modules/homework/types";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (payload: SubmitHomeworkPayload) => Promise<void>;
+  initialContent?: string | null;
+  initialAttachments?: { filename: string; url: string }[] | null;
+};
+
+export function SubmissionDialog({
+  open,
+  onClose,
+  onSubmit,
+  initialContent,
+  initialAttachments,
+}: Props) {
+  const [attachments, setAttachments] = useState<
+    { filename: string; url: string }[]
+  >([]);
+  const form = useForm<SubmitHomeworkValues>({
+    resolver: zodResolver(
+      submitHomeworkSchema,
+    ) as unknown as Resolver<SubmitHomeworkValues>,
+    mode: "onChange",
+    defaultValues: { content: "" },
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    form.reset({ content: initialContent ?? "" });
+    setAttachments(initialAttachments ?? []);
+  }, [open, initialContent, initialAttachments, form]);
+
+  if (!open) return null;
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    try {
+      await onSubmit({
+        content: values.content?.trim() || undefined,
+        attachments: attachments.filter((a) => a.filename && a.url),
+      });
+      onClose();
+    } catch (err) {
+      const message = axios.isAxiosError(err)
+        ? (err.response?.data as { message?: string | string[] })?.message
+        : null;
+      form.setError("root", {
+        message: Array.isArray(message)
+          ? message.join(", ")
+          : message || "Submission failed",
+      });
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/40 p-4">
+      <div className="max-h-[90vh] w-full max-w-xl overflow-y-auto rounded-lg bg-white p-5 shadow-xl">
+        <h2 className="mb-1 text-lg font-semibold text-[#021034]">
+          Submit work
+        </h2>
+        <p className="mb-4 text-sm text-slate-600">
+          Add your answer text and optional attachment links.
+        </p>
+        <Form onSubmit={handleSubmit} className="space-y-4">
+          <FormField>
+            <FormLabel>Content</FormLabel>
+            <FormControl>
+              <Textarea rows={5} {...form.register("content")} />
+            </FormControl>
+            <FormMessage>{form.formState.errors.content?.message}</FormMessage>
+          </FormField>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <FormLabel>Attachments</FormLabel>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() =>
+                  setAttachments((prev) => [...prev, { filename: "", url: "" }])
+                }
+              >
+                + Add
+              </Button>
+            </div>
+            {attachments.map((a, idx) => (
+              <div key={idx} className="grid gap-2 sm:grid-cols-[1fr_2fr_auto]">
+                <Input
+                  placeholder="Filename"
+                  value={a.filename}
+                  onChange={(e) =>
+                    setAttachments((prev) =>
+                      prev.map((item, i) =>
+                        i === idx ? { ...item, filename: e.target.value } : item,
+                      ),
+                    )
+                  }
+                />
+                <Input
+                  placeholder="https://..."
+                  value={a.url}
+                  onChange={(e) =>
+                    setAttachments((prev) =>
+                      prev.map((item, i) =>
+                        i === idx ? { ...item, url: e.target.value } : item,
+                      ),
+                    )
+                  }
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() =>
+                    setAttachments((prev) => prev.filter((_, i) => i !== idx))
+                  }
+                >
+                  Remove
+                </Button>
+              </div>
+            ))}
+          </div>
+
+          {form.formState.errors.root?.message && (
+            <p className="text-sm text-red-600">
+              {form.formState.errors.root.message}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="dark"
+              disabled={form.formState.isSubmitting}
+            >
+              {form.formState.isSubmitting ? "Submitting…" : "Submit"}
+            </Button>
+          </div>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/homework/constants/query-keys.ts
+++ b/src/modules/homework/constants/query-keys.ts
@@ -1,0 +1,19 @@
+export const HOMEWORK_PAGE_SIZE = 10;
+
+export const homeworkQueryKeys = {
+  all: ["homework"] as const,
+  teacherLists: () => [...homeworkQueryKeys.all, "teacher-list"] as const,
+  teacherList: (q?: Record<string, unknown>) =>
+    [...homeworkQueryKeys.teacherLists(), q ?? {}] as const,
+  adminLists: () => [...homeworkQueryKeys.all, "admin-list"] as const,
+  adminList: (q?: Record<string, unknown>) =>
+    [...homeworkQueryKeys.adminLists(), q ?? {}] as const,
+  studentLists: () => [...homeworkQueryKeys.all, "student-list"] as const,
+  studentList: (q?: Record<string, unknown>) =>
+    [...homeworkQueryKeys.studentLists(), q ?? {}] as const,
+  detail: (id: string) => [...homeworkQueryKeys.all, "detail", id] as const,
+  studentDetail: (id: string) =>
+    [...homeworkQueryKeys.all, "student-detail", id] as const,
+  submissions: (id: string, q?: Record<string, unknown>) =>
+    [...homeworkQueryKeys.all, "submissions", id, q ?? {}] as const,
+};

--- a/src/modules/homework/hooks/useHomework.ts
+++ b/src/modules/homework/hooks/useHomework.ts
@@ -1,0 +1,159 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createHomework,
+  deleteHomework,
+  fetchHomeworkDetail,
+  fetchHomeworkList,
+  fetchStudentHomeworkDetail,
+  fetchStudentHomeworkList,
+  fetchSubmissions,
+  reviewSubmission,
+  submitHomework,
+  updateHomework,
+  updateHomeworkStatus,
+} from "@/modules/homework/api/homework";
+import {
+  HOMEWORK_PAGE_SIZE,
+  homeworkQueryKeys,
+} from "@/modules/homework/constants/query-keys";
+import type {
+  CreateHomeworkPayload,
+  HomeworkQuery,
+  ReviewSubmissionPayload,
+  SubmissionQuery,
+  SubmitHomeworkPayload,
+  UpdateHomeworkPayload,
+} from "@/modules/homework/types";
+
+export function useHomeworkList(
+  scope: "admin" | "teacher",
+  query: HomeworkQuery = {},
+) {
+  const q = { page: 1, limit: HOMEWORK_PAGE_SIZE, ...query };
+  return useQuery({
+    queryKey:
+      scope === "admin"
+        ? homeworkQueryKeys.adminList(q)
+        : homeworkQueryKeys.teacherList(q),
+    queryFn: () => fetchHomeworkList(scope, q),
+  });
+}
+
+export function useAdminHomeworkList(query: HomeworkQuery = {}) {
+  return useHomeworkList("admin", query);
+}
+
+export function useTeacherHomeworkList(query: HomeworkQuery = {}) {
+  return useHomeworkList("teacher", query);
+}
+
+export function useStudentHomeworkList(query: HomeworkQuery = {}) {
+  const q = { page: 1, limit: HOMEWORK_PAGE_SIZE, ...query };
+  return useQuery({
+    queryKey: homeworkQueryKeys.studentList(q),
+    queryFn: () => fetchStudentHomeworkList(q),
+  });
+}
+
+export function useHomeworkDetail(
+  scope: "admin" | "teacher",
+  id: string | undefined,
+) {
+  return useQuery({
+    queryKey: homeworkQueryKeys.detail(id ?? ""),
+    queryFn: () => fetchHomeworkDetail(scope, id!),
+    enabled: Boolean(id),
+  });
+}
+
+export function useStudentHomeworkDetail(id: string | undefined) {
+  return useQuery({
+    queryKey: homeworkQueryKeys.studentDetail(id ?? ""),
+    queryFn: () => fetchStudentHomeworkDetail(id!),
+    enabled: Boolean(id),
+  });
+}
+
+export function useHomeworkSubmissions(
+  scope: "admin" | "teacher",
+  homeworkId: string | undefined,
+  query: SubmissionQuery = {},
+) {
+  const q = { page: 1, limit: 20, ...query };
+  return useQuery({
+    queryKey: homeworkQueryKeys.submissions(homeworkId ?? "", q),
+    queryFn: () => fetchSubmissions(scope, homeworkId!, q),
+    enabled: Boolean(homeworkId),
+  });
+}
+
+export function useHomeworkMutations(scope: "admin" | "teacher") {
+  const qc = useQueryClient();
+  const invalidate = () =>
+    qc.invalidateQueries({ queryKey: homeworkQueryKeys.all });
+
+  const create = useMutation({
+    mutationFn: (payload: CreateHomeworkPayload) =>
+      createHomework(scope, payload),
+    onSuccess: invalidate,
+  });
+
+  const update = useMutation({
+    mutationFn: ({
+      id,
+      payload,
+    }: {
+      id: string;
+      payload: UpdateHomeworkPayload;
+    }) => updateHomework(scope, id, payload),
+    onSuccess: invalidate,
+  });
+
+  const setStatus = useMutation({
+    mutationFn: ({
+      id,
+      status,
+    }: {
+      id: string;
+      status: "DRAFT" | "PUBLISHED" | "CLOSED";
+    }) => updateHomeworkStatus(scope, id, status),
+    onSuccess: invalidate,
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) => deleteHomework(scope, id),
+    onSuccess: invalidate,
+  });
+
+  const review = useMutation({
+    mutationFn: ({
+      homeworkId,
+      submissionId,
+      payload,
+    }: {
+      homeworkId: string;
+      submissionId: string;
+      payload: ReviewSubmissionPayload;
+    }) => reviewSubmission(scope, homeworkId, submissionId, payload),
+    onSuccess: invalidate,
+  });
+
+  return { create, update, setStatus, remove, review };
+}
+
+export function useSubmitHomeworkMutation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      homeworkId,
+      payload,
+    }: {
+      homeworkId: string;
+      payload: SubmitHomeworkPayload;
+    }) => submitHomework(homeworkId, payload),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: homeworkQueryKeys.all }),
+  });
+}

--- a/src/modules/homework/index.ts
+++ b/src/modules/homework/index.ts
@@ -1,0 +1,15 @@
+export { HomeworkListPage } from "./components/HomeworkListPage";
+export * from "./types";
+export * from "./api/homework";
+export * from "./hooks/useHomework";
+export * from "./constants/query-keys";
+export * from "./schemas/homework.schemas";
+export * from "./utils/format";
+export { HomeworkSubnav } from "./components/HomeworkSubnav";
+export { HomeworkDialog } from "./components/HomeworkDialog";
+export { SubmissionDialog } from "./components/SubmissionDialog";
+export { ReviewDialog } from "./components/ReviewDialog";
+export {
+  HomeworkStatusBadge,
+  SubmissionStatusBadge,
+} from "./components/HomeworkStatusBadge";

--- a/src/modules/homework/schemas/homework.schemas.ts
+++ b/src/modules/homework/schemas/homework.schemas.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+const attachmentSchema = z.object({
+  filename: z.string().min(1, "Filename required"),
+  url: z.string().url("Valid URL required"),
+});
+
+export const createHomeworkSchema = z.object({
+  title: z.string().trim().min(1, "Title is required").max(255),
+  description: z.string().optional().or(z.literal("")),
+  type: z.enum(["HOMEWORK", "ASSIGNMENT"]),
+  subjectId: z.string().uuid("Select a subject").optional().or(z.literal("")),
+  dueAt: z.string().min(1, "Due date is required"),
+  maxMarks: z.coerce.number().min(0).optional().or(z.nan()).optional(),
+  allowLateSubmission: z.boolean().default(true),
+  classIds: z.array(z.string().uuid()).min(1, "Select at least one class"),
+  attachments: z.array(attachmentSchema).optional(),
+});
+
+export type CreateHomeworkValues = z.infer<typeof createHomeworkSchema>;
+
+export const submitHomeworkSchema = z
+  .object({
+    content: z.string().optional().or(z.literal("")),
+    attachments: z.array(attachmentSchema).optional(),
+  })
+  .refine(
+    (v) =>
+      Boolean(v.content?.trim()) ||
+      Boolean(v.attachments && v.attachments.length > 0),
+    { message: "Provide content or at least one attachment", path: ["content"] },
+  );
+
+export type SubmitHomeworkValues = z.infer<typeof submitHomeworkSchema>;
+
+export const reviewSubmissionSchema = z.object({
+  marksObtained: z.coerce.number().min(0).optional().or(z.nan()).optional(),
+  remarks: z.string().optional().or(z.literal("")),
+  status: z.enum(["REVIEWED", "RETURNED"]).default("REVIEWED"),
+});
+
+export type ReviewSubmissionValues = z.infer<typeof reviewSubmissionSchema>;

--- a/src/modules/homework/types/index.ts
+++ b/src/modules/homework/types/index.ts
@@ -1,0 +1,119 @@
+export type HomeworkType = "HOMEWORK" | "ASSIGNMENT";
+export type HomeworkStatus = "DRAFT" | "PUBLISHED" | "CLOSED";
+export type SubmissionStatus =
+  | "NOT_SUBMITTED"
+  | "SUBMITTED"
+  | "LATE"
+  | "REVIEWED"
+  | "RETURNED";
+
+export type HomeworkAttachment = {
+  filename: string;
+  url: string;
+};
+
+export type HomeworkClass = {
+  id: string;
+  classId: string;
+  className: string;
+  section: string | null;
+};
+
+export type Homework = {
+  id: string;
+  schoolId: string;
+  title: string;
+  description: string | null;
+  type: HomeworkType;
+  subjectId: string | null;
+  subjectName: string | null;
+  createdByUserId: string;
+  createdByName: string | null;
+  dueAt: string;
+  maxMarks: number | null;
+  allowLateSubmission: boolean;
+  status: HomeworkStatus;
+  attachments: HomeworkAttachment[] | null;
+  classes: HomeworkClass[];
+  mySubmissionStatus?: SubmissionStatus;
+  submissionCount?: number;
+  reviewedCount?: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type HomeworkSubmission = {
+  id: string;
+  schoolId: string;
+  homeworkId: string;
+  studentUserId: string;
+  studentName: string | null;
+  classId: string;
+  className: string | null;
+  content: string | null;
+  attachments: HomeworkAttachment[] | null;
+  status: SubmissionStatus;
+  submittedAt: string | null;
+  isLate: boolean;
+  marksObtained: number | null;
+  remarks: string | null;
+  reviewedByUserId: string | null;
+  reviewedByName: string | null;
+  reviewedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type StudentHomeworkDetail = Homework & {
+  mySubmission: HomeworkSubmission | null;
+};
+
+export type Paginated<T> = {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
+export type HomeworkQuery = {
+  page?: number;
+  limit?: number;
+  search?: string;
+  type?: HomeworkType;
+  status?: HomeworkStatus;
+  classId?: string;
+  subjectId?: string;
+};
+
+export type CreateHomeworkPayload = {
+  title: string;
+  description?: string;
+  type: HomeworkType;
+  subjectId?: string;
+  dueAt: string;
+  maxMarks?: number;
+  allowLateSubmission?: boolean;
+  attachments?: HomeworkAttachment[];
+  classIds: string[];
+};
+
+export type UpdateHomeworkPayload = Partial<CreateHomeworkPayload>;
+
+export type SubmitHomeworkPayload = {
+  content?: string;
+  attachments?: HomeworkAttachment[];
+};
+
+export type ReviewSubmissionPayload = {
+  marksObtained?: number;
+  remarks?: string;
+  status?: "REVIEWED" | "RETURNED";
+};
+
+export type SubmissionQuery = {
+  page?: number;
+  limit?: number;
+  status?: SubmissionStatus;
+  classId?: string;
+  search?: string;
+};

--- a/src/modules/homework/utils/format.ts
+++ b/src/modules/homework/utils/format.ts
@@ -1,0 +1,68 @@
+import type {
+  HomeworkStatus,
+  HomeworkType,
+  SubmissionStatus,
+} from "@/modules/homework/types";
+
+export const HOMEWORK_TYPE_LABELS: Record<HomeworkType, string> = {
+  HOMEWORK: "Homework",
+  ASSIGNMENT: "Assignment",
+};
+
+export const HOMEWORK_STATUS_LABELS: Record<HomeworkStatus, string> = {
+  DRAFT: "Draft",
+  PUBLISHED: "Published",
+  CLOSED: "Closed",
+};
+
+export const SUBMISSION_STATUS_LABELS: Record<SubmissionStatus, string> = {
+  NOT_SUBMITTED: "Not submitted",
+  SUBMITTED: "Submitted",
+  LATE: "Late",
+  REVIEWED: "Reviewed",
+  RETURNED: "Returned",
+};
+
+export function homeworkStatusClass(status: HomeworkStatus): string {
+  switch (status) {
+    case "DRAFT":
+      return "rounded-md bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700";
+    case "PUBLISHED":
+      return "rounded-md bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-700";
+    case "CLOSED":
+      return "rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800";
+    default:
+      return "rounded-md bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700";
+  }
+}
+
+export function submissionStatusClass(status: SubmissionStatus): string {
+  switch (status) {
+    case "NOT_SUBMITTED":
+      return "rounded-md bg-slate-100 px-2 py-1 text-xs font-medium text-slate-600";
+    case "SUBMITTED":
+      return "rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700";
+    case "LATE":
+      return "rounded-md bg-orange-50 px-2 py-1 text-xs font-medium text-orange-700";
+    case "REVIEWED":
+      return "rounded-md bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-700";
+    case "RETURNED":
+      return "rounded-md bg-rose-50 px-2 py-1 text-xs font-medium text-rose-700";
+    default:
+      return "rounded-md bg-slate-100 px-2 py-1 text-xs font-medium text-slate-600";
+  }
+}
+
+export function formatDueAt(value: string | Date): string {
+  const d = typeof value === "string" ? new Date(value) : value;
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+export function isOverdue(dueAt: string, status?: HomeworkStatus): boolean {
+  if (status === "CLOSED") return false;
+  return new Date(dueAt).getTime() < Date.now();
+}

--- a/src/modules/teachers/api/portal.ts
+++ b/src/modules/teachers/api/portal.ts
@@ -20,6 +20,7 @@ export type AssignedClass = {
 
 export type AssignedSubject = {
   subjectId: string;
+  classId?: string;
   class: string;
   section: string;
   subject: string;


### PR DESCRIPTION
## Summary
- Add teacher, admin, and student homework screens for listing, creating/editing, submitting, and reviewing work with status indicators.
- Wire API routes, nav items, and a reusable homework module (hooks, dialogs, schemas) that reuses existing UI patterns.
- Use teacher dashboard class/subject options (including `classId`) so teachers do not depend on admin-only list APIs.

## Test plan
- [ ] Open `/teacher/homework`, create homework/assignment for assigned classes, publish
- [ ] Open `/admin/homework` and verify list/edit/submissions review flow
- [ ] As student, open `/student/homework`, submit work, and see late/reviewed status
- [ ] Confirm nav links appear for admin, teacher, and student roles
- [ ] Verify responsive layout on mobile and desktop list/detail pages
- [ ] Pair with backend homework PR and smoke-test end-to-end submit → review


Made with [Cursor](https://cursor.com)