### PR TITLE
Add Parent & Student Portal UI

### DIFF
--- a/src/app/admin/parents/[parentId]/page.tsx
+++ b/src/app/admin/parents/[parentId]/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import {
+  ParentDetailView,
+  useParentQuery,
+} from "@/modules/parents";
+
+export default function AdminParentDetailPage() {
+  const params = useParams();
+  const parentId = String(params?.parentId ?? "");
+
+  const { data, isLoading, error, refetch } = useParentQuery(
+    parentId || undefined,
+  );
+
+  if (error) {
+    return (
+      <div className="mx-auto px-4 py-6">
+        <Card>
+          <div className="flex flex-col items-start gap-4">
+            <div className="text-sm text-slate-700">
+              Error:{" "}
+              {error instanceof Error
+                ? error.message
+                : "Failed to load parent"}
+            </div>
+            <div className="flex gap-2">
+              <Button onClick={() => void refetch()}>Retry</Button>
+              <Link href="/admin/parents">
+                <Button variant="ghost">Back to list</Button>
+              </Link>
+            </div>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <div>
+          <Link
+            href="/admin/parents"
+            className="text-sm text-slate-500 hover:text-slate-800"
+          >
+            ← Back to Parents
+          </Link>
+          <h1 className="mt-2 text-[24px] font-[600] text-[#021034]">
+            Parent Details
+          </h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            View profile and manage linked children
+          </p>
+        </div>
+      </div>
+
+      {data ? (
+        <ParentDetailView
+          parent={data}
+          loading={isLoading}
+          onChanged={() => void refetch()}
+        />
+      ) : (
+        <ParentDetailView
+          parent={{
+            id: parentId,
+            email: "",
+            firstName: "",
+            lastName: "",
+            fullName: "",
+            status: "",
+            childrenCount: 0,
+            children: [],
+          }}
+          loading
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/parents/page.tsx
+++ b/src/app/admin/parents/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import Button from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import Card from "@/components/ui/Card";
+import {
+  CreateParentDialog,
+  ParentsTable,
+  PARENTS_PAGE_SIZE,
+  parentQueryKeys,
+  useParentsQuery,
+} from "@/modules/parents";
+
+export default function AdminParentsPage() {
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [appliedSearch, setAppliedSearch] = useState("");
+  const [creatingOpen, setCreatingOpen] = useState(false);
+
+  const { data, isLoading, isFetching, error, refetch } = useParentsQuery({
+    search: appliedSearch || undefined,
+    page,
+    pageSize: PARENTS_PAGE_SIZE,
+  });
+
+  const handleSearchApply = useCallback(() => {
+    setAppliedSearch(search.trim());
+    setPage(1);
+  }, [search]);
+
+  const parents = data?.parents ?? [];
+  const total = data?.total ?? 0;
+  const errorMessage =
+    error instanceof Error
+      ? error.message
+      : error
+        ? "Failed to load parents"
+        : null;
+
+  return (
+    <div className="mx-auto px-4 py-6">
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-[24px] font-[600] text-[#021034]">Parents</h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            Create parent accounts and link them to students
+          </p>
+        </div>
+        <Button variant="dark" onClick={() => setCreatingOpen(true)}>
+          + Add Parent
+        </Button>
+      </div>
+
+      <Card className="mb-5">
+        <div className="flex flex-col sm:flex-row gap-3 sm:items-end">
+          <div className="flex-1">
+            <label className="sr-only">Search parents</label>
+            <Input
+              className="bg-[#F5F9FF]"
+              placeholder="Search by name, email, or mobile"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSearchApply();
+              }}
+            />
+          </div>
+          <div className="flex gap-2">
+            <Button variant="dark" onClick={handleSearchApply}>
+              Search
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setSearch("");
+                setAppliedSearch("");
+                setPage(1);
+              }}
+            >
+              Clear
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      <ParentsTable
+        parents={parents}
+        loading={isLoading || isFetching}
+        error={errorMessage}
+        total={total}
+        page={page}
+        pageSize={PARENTS_PAGE_SIZE}
+        onRetry={() => void refetch()}
+        onPageChange={setPage}
+      />
+
+      <CreateParentDialog
+        open={creatingOpen}
+        onClose={() => setCreatingOpen(false)}
+        onCreated={() => {
+          void queryClient.invalidateQueries({
+            queryKey: parentQueryKeys.all,
+          });
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,16 +2,30 @@
 import React, { useState } from "react";
 import Image from "next/image";
 import UnifiedLoginForm from "@/modules/auth/components/UnifiedLoginForm";
-import Button from "../../components/ui/Button";
+import type { Role } from "@/types/auth";
+
+const LOGIN_ROLES: Role[] = ["admin", "teacher", "student", "parent"];
+
+function portalTitle(role: Role) {
+  switch (role) {
+    case "admin":
+      return "Admin Portal";
+    case "teacher":
+      return "Teacher Portal";
+    case "student":
+      return "Student Portal";
+    case "parent":
+      return "Parent Portal";
+  }
+}
 
 export default function Page() {
-  const [role, setRole] = useState<"admin" | "teacher" | "student">("admin");
+  const [role, setRole] = useState<Role>("admin");
 
   return (
     <>
       <div className="flex items-center justify-center h-screen overflow-hidden">
         <div className="relative w-full h-screen lg:flex hidden">
-          {/* Image */}
           <Image
             src="/images/Login.png"
             alt="Teacher Login Illustration"
@@ -19,7 +33,6 @@ export default function Page() {
             className="object-cover lg:flex hidden"
           />
 
-          {/* Overlay text */}
           <div className="absolute w-1/2 lg:flex items-start justify-start hidden flex-col pl-12 pt-12">
             <div className="w-full flex items-center mb-92">
               <h1 className="font-bold text-2xl text-white max-w-[100px]">
@@ -33,7 +46,7 @@ export default function Page() {
               <h1 className="text-[48px] font-[600] leading-[56px] mb-4">
                 Sign in to SchoolConnect
               </h1>
-              <p>Secure access For Admin, Teachers and Student</p>
+              <p>Secure access for Admin, Teachers, Students and Parents</p>
             </div>
           </div>
         </div>
@@ -49,21 +62,16 @@ export default function Page() {
                 className="mx-auto h-16 w-auto mb-5"
               />
               <h1 className="text-xl font-semibold text-slate-900 text-center">
-                Sign in to{" "}
-                {role === "admin"
-                  ? " Admin Portal"
-                  : role === "teacher"
-                    ? " Teacher Portal"
-                    : " Student Portal"}
+                Sign in to {portalTitle(role)}
               </h1>
               <p className="mt-1 text-sm text-slate-500 text-center">
-                Secure access for Admins, Teachers and Students.
+                Secure access for Admins, Teachers, Students and Parents.
               </p>
             </div>
 
             <div className="mb-4" role="tablist" aria-label="Login role">
-              <div className="flex gap-2 bg-[#EEF4FF] p-1 rounded-lg w-fit">
-                {(["admin", "teacher", "student"] as const).map((r) => {
+              <div className="flex flex-wrap gap-2 bg-[#EEF4FF] p-1 rounded-lg w-fit justify-center">
+                {LOGIN_ROLES.map((r) => {
                   const active = role === r;
                   return (
                     <button

--- a/src/app/parent/children/[studentId]/announcements/page.tsx
+++ b/src/app/parent/children/[studentId]/announcements/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { ChildAnnouncementsView } from "@/modules/parent-portal";
+
+export default function ParentChildAnnouncementsPage({
+  params,
+}: {
+  params: Promise<{ studentId: string }>;
+}) {
+  const { studentId } = use(params);
+  return <ChildAnnouncementsView studentId={studentId} />;
+}

--- a/src/app/parent/children/[studentId]/attendance/page.tsx
+++ b/src/app/parent/children/[studentId]/attendance/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { ChildAttendanceView } from "@/modules/parent-portal";
+
+export default function ParentChildAttendancePage({
+  params,
+}: {
+  params: Promise<{ studentId: string }>;
+}) {
+  const { studentId } = use(params);
+  return <ChildAttendanceView studentId={studentId} />;
+}

--- a/src/app/parent/children/[studentId]/documents/page.tsx
+++ b/src/app/parent/children/[studentId]/documents/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { ChildDocumentsView } from "@/modules/parent-portal";
+
+export default function ParentChildDocumentsPage({
+  params,
+}: {
+  params: Promise<{ studentId: string }>;
+}) {
+  const { studentId } = use(params);
+  return <ChildDocumentsView studentId={studentId} />;
+}

--- a/src/app/parent/children/[studentId]/exams/page.tsx
+++ b/src/app/parent/children/[studentId]/exams/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { ChildExamsView } from "@/modules/parent-portal";
+
+export default function ParentChildExamsPage({
+  params,
+}: {
+  params: Promise<{ studentId: string }>;
+}) {
+  const { studentId } = use(params);
+  return <ChildExamsView studentId={studentId} />;
+}

--- a/src/app/parent/children/[studentId]/fees/page.tsx
+++ b/src/app/parent/children/[studentId]/fees/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { ChildFeesView } from "@/modules/parent-portal";
+
+export default function ParentChildFeesPage({
+  params,
+}: {
+  params: Promise<{ studentId: string }>;
+}) {
+  const { studentId } = use(params);
+  return <ChildFeesView studentId={studentId} />;
+}

--- a/src/app/parent/children/[studentId]/homework/[homeworkId]/page.tsx
+++ b/src/app/parent/children/[studentId]/homework/[homeworkId]/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { use } from "react";
+import { ChildHomeworkDetailView } from "@/modules/parent-portal";
+
+export default function ParentChildHomeworkDetailPage({
+  params,
+}: {
+  params: Promise<{ studentId: string; homeworkId: string }>;
+}) {
+  const { studentId, homeworkId } = use(params);
+  return (
+    <ChildHomeworkDetailView studentId={studentId} homeworkId={homeworkId} />
+  );
+}

--- a/src/app/parent/children/[studentId]/homework/page.tsx
+++ b/src/app/parent/children/[studentId]/homework/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { ChildHomeworkListView } from "@/modules/parent-portal";
+
+export default function ParentChildHomeworkPage({
+  params,
+}: {
+  params: Promise<{ studentId: string }>;
+}) {
+  const { studentId } = use(params);
+  return <ChildHomeworkListView studentId={studentId} />;
+}

--- a/src/app/parent/children/[studentId]/layout.tsx
+++ b/src/app/parent/children/[studentId]/layout.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { use } from "react";
+import { ChildSubnav, ChildSwitcher } from "@/modules/parent-portal";
+
+export default function ParentChildLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ studentId: string }>;
+}) {
+  const { studentId } = use(params);
+
+  return (
+    <div>
+      <div className="mx-auto px-4 pt-4">
+        <ChildSwitcher studentId={studentId} />
+        <div className="mt-4">
+          <ChildSubnav studentId={studentId} />
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/app/parent/children/[studentId]/page.tsx
+++ b/src/app/parent/children/[studentId]/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { ChildDashboardView } from "@/modules/parent-portal";
+
+export default function ParentChildDashboardPage({
+  params,
+}: {
+  params: Promise<{ studentId: string }>;
+}) {
+  const { studentId } = use(params);
+  return <ChildDashboardView studentId={studentId} />;
+}

--- a/src/app/parent/children/[studentId]/profile/page.tsx
+++ b/src/app/parent/children/[studentId]/profile/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { ChildProfileView } from "@/modules/parent-portal";
+
+export default function ParentChildProfilePage({
+  params,
+}: {
+  params: Promise<{ studentId: string }>;
+}) {
+  const { studentId } = use(params);
+  return <ChildProfileView studentId={studentId} />;
+}

--- a/src/app/parent/children/[studentId]/timetable/page.tsx
+++ b/src/app/parent/children/[studentId]/timetable/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { ChildTimetableView } from "@/modules/parent-portal";
+
+export default function ParentChildTimetablePage({
+  params,
+}: {
+  params: Promise<{ studentId: string }>;
+}) {
+  const { studentId } = use(params);
+  return <ChildTimetableView studentId={studentId} />;
+}

--- a/src/app/parent/children/page.tsx
+++ b/src/app/parent/children/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ChildrenListView } from "@/modules/parent-portal";
+
+export default function ParentChildrenPage() {
+  return <ChildrenListView />;
+}

--- a/src/app/parent/dashboard/page.tsx
+++ b/src/app/parent/dashboard/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ParentDashboardView } from "@/modules/parent-portal";
+
+export default function ParentDashboardPage() {
+  return <ParentDashboardView />;
+}

--- a/src/app/student/announcements/page.tsx
+++ b/src/app/student/announcements/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import React from "react";
+import { Megaphone } from "lucide-react";
+import {
+  getClassAnnouncements,
+  type StudentAnnouncementItem,
+} from "@/modules/students";
+import { ensureSessionReady } from "@/modules/auth";
+import { useToast } from "@/components/ui/use-toast";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { AnnouncementsPageSkeleton } from "@/modules/announcements";
+
+const PAGE_SIZE = 10;
+
+export default function StudentAnnouncementsPage() {
+  const [items, setItems] = React.useState<StudentAnnouncementItem[]>([]);
+  const [page, setPage] = React.useState(1);
+  const [total, setTotal] = React.useState(0);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const { toast } = useToast();
+  const toastRef = React.useRef(toast);
+
+  React.useEffect(() => {
+    toastRef.current = toast;
+  }, [toast]);
+
+  const load = React.useCallback(async (p: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      await ensureSessionReady();
+      const data = await getClassAnnouncements(p, PAGE_SIZE);
+      setItems(data.items);
+      setTotal(data.total);
+      setPage(data.page);
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Failed to load announcements";
+      setError(message);
+      toastRef.current?.({
+        title: "Error",
+        description: message,
+        type: "error",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void load(page);
+  }, [load, page]);
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const isInitial = loading && items.length === 0 && !error;
+
+  if (isInitial) {
+    return <AnnouncementsPageSkeleton />;
+  }
+
+  return (
+    <div className="mx-auto px-4 py-6 bg-[#F5F9FF] min-h-full">
+      <div className="mb-6 flex items-start gap-3">
+        <Megaphone className="mt-1 h-5 w-5 text-[#021034]" />
+        <div>
+          <h1 className="text-[24px] font-[600] text-[#021034]">
+            Announcements
+          </h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            School-wide and class announcements
+          </p>
+        </div>
+      </div>
+
+      {error && items.length === 0 ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-slate-700">{error}</p>
+            <Button variant="dark" onClick={() => void load(page)}>
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : items.length === 0 ? (
+        <Card>
+          <p className="py-8 text-center text-sm text-slate-500">
+            No announcements yet.
+          </p>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {loading ? (
+            <p className="text-sm text-slate-500">Loading…</p>
+          ) : null}
+          {items.map((a) => (
+            <div
+              key={a.id}
+              className="w-full rounded-xl border border-[#D7E3FC] bg-white px-6 py-5"
+            >
+              <div className="flex flex-wrap items-center gap-2 text-sm text-gray-500">
+                {a.pinned ? (
+                  <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+                    Pinned
+                  </span>
+                ) : null}
+                <span className="text-[13px]">
+                  {a.publishedAt
+                    ? new Date(a.publishedAt).toLocaleString()
+                    : ""}
+                </span>
+                {a.authorName ? (
+                  <span className="text-[13px]">· {a.authorName}</span>
+                ) : null}
+              </div>
+              <h2 className="mt-3 text-[18px] font-[600] text-[#021034]">
+                {a.title}
+              </h2>
+              <p className="mt-2 whitespace-pre-wrap text-[14px] leading-relaxed text-[#737373]">
+                {a.body}
+              </p>
+            </div>
+          ))}
+
+          {totalPages > 1 ? (
+            <div className="flex items-center justify-between pt-2">
+              <p className="text-sm text-slate-500">
+                Page {page} of {totalPages}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="ghost"
+                  disabled={page <= 1 || loading}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="ghost"
+                  disabled={page >= totalPages || loading}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/student/dashboard/page.tsx
+++ b/src/app/student/dashboard/page.tsx
@@ -1,29 +1,43 @@
 "use client";
+
 import React from "react";
+import Link from "next/link";
 import {
-  getStudentMe,
-  getAttendanceSummary,
+  CalendarDays,
+  ChevronRight,
+  FileText,
+  Megaphone,
+  Clock,
+} from "lucide-react";
+import {
+  getStudentDashboard,
   StudentDashboardSkeleton,
+  type StudentDashboard,
 } from "@/modules/students";
 import { useToast } from "@/components/ui/use-toast";
 import { AttendanceSummary } from "@/modules/dashboard";
 import DocumentsGrid from "@/modules/documents/components/DocumentsGrid";
 import { ensureSessionReady } from "@/modules/auth";
+import Button from "@/components/ui/Button";
+import { DOCUMENT_TYPES } from "@/modules/documents/constants";
 
-function num(v: unknown, fallback = 0): number {
-  if (typeof v === "number" && Number.isFinite(v)) return v;
-  if (typeof v === "string" && v.trim() !== "" && !Number.isNaN(Number(v))) {
-    return Number(v);
-  }
-  return fallback;
+function formatClassLabel(
+  cls?: { name: string; section?: string | null } | null,
+): string {
+  if (!cls?.name) return "Not assigned";
+  return cls.section ? `${cls.name} - ${cls.section}` : cls.name;
+}
+
+function docTypeLabel(value: string): string {
+  return DOCUMENT_TYPES.find((t) => t.value === value)?.label ?? value;
 }
 
 export default function StudentDashboardPage() {
-  const [me, setMe] = React.useState<Record<string, unknown> | null>(null);
-  const [summary, setSummary] = React.useState<Record<string, unknown> | null>(
+  const [dashboard, setDashboard] = React.useState<StudentDashboard | null>(
     null,
   );
   const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
   const { toast } = useToast();
   const toastRef = React.useRef(toast);
 
@@ -31,158 +45,254 @@ export default function StudentDashboardPage() {
     toastRef.current = toast;
   }, [toast]);
 
-  React.useEffect(() => {
-    let mounted = true;
-    async function load() {
-      try {
-        await ensureSessionReady();
-        if (!mounted) return;
-        const [meData, summaryData] = await Promise.all([
-          getStudentMe(),
-          getAttendanceSummary(),
-        ]);
-        if (!mounted) return;
-        setMe(meData);
-        setSummary(summaryData);
-      } catch (err: unknown) {
-        const message =
-          err && typeof err === "object" && "message" in err
-            ? String((err as { message?: unknown }).message ?? "Failed to load")
-            : "Failed to load";
-        toastRef.current?.({
-          title: "Error",
-          description: message,
-          type: "error",
-        });
-      } finally {
-        if (mounted) setLoading(false);
-      }
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await ensureSessionReady();
+      const data = await getStudentDashboard();
+      setDashboard(data);
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === "object" && "message" in err
+          ? String((err as { message?: unknown }).message ?? "Failed to load")
+          : "Failed to load dashboard";
+      setError(message);
+      toastRef.current?.({
+        title: "Error",
+        description: message,
+        type: "error",
+      });
+    } finally {
+      setLoading(false);
     }
-    load();
-    return () => {
-      mounted = false;
-    };
   }, []);
 
-  const displayName =
-    (typeof me?.fullName === "string" && me.fullName) ||
-    (typeof me?.name === "string" && me.name) ||
-    "Student";
-
-  const presentDays = num(
-    summary?.presentDays ?? summary?.present ?? summary?.presentCount,
-    0,
-  );
-  const absentDays = num(
-    summary?.absentDays ?? summary?.absent ?? summary?.absentCount,
-    0,
-  );
-  const monthlyPercentage = num(
-    summary?.monthlyPercentage ?? summary?.percentage ?? summary?.attendancePercentage,
-    presentDays + absentDays > 0
-      ? Math.round((presentDays / (presentDays + absentDays)) * 100)
-      : 0,
-  );
-
-  const schedule = Array.isArray(me?.todaySchedule)
-    ? (me.todaySchedule as Array<Record<string, unknown>>)
-    : Array.isArray(summary?.todaySchedule)
-      ? (summary.todaySchedule as Array<Record<string, unknown>>)
-      : [];
+  React.useEffect(() => {
+    void load();
+  }, [load]);
 
   if (loading) {
     return <StudentDashboardSkeleton />;
   }
 
+  if (error && !dashboard) {
+    return (
+      <div className="p-6">
+        <div className="rounded-xl border border-[#D7E3FC] bg-white p-8 text-center">
+          <p className="text-sm text-slate-700 mb-4">{error}</p>
+          <Button variant="dark" onClick={() => void load()}>
+            Retry
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const displayName = dashboard?.profile?.fullName ?? "Student";
+  const presentDays = dashboard?.presentDays ?? 0;
+  const absentDays = dashboard?.absentDays ?? 0;
+  const monthlyPercentage = dashboard?.attendancePercentage ?? 0;
+  const timetable = dashboard?.timetable ?? [];
+  const announcements = dashboard?.recentAnnouncements ?? [];
+  const documents = dashboard?.documents?.items ?? [];
+  const currentClass = dashboard?.currentClass ?? dashboard?.profile?.class;
+
+  const documentItems = documents.map((doc) => ({
+    id: doc.id,
+    title: doc.originalName || doc.fileName || docTypeLabel(doc.documentType),
+    type: docTypeLabel(doc.documentType),
+    href: doc.url,
+  }));
+
   return (
-    <div className="p-6">
-      <div>
-        <section className="pl-2">
-          <div className="mb-6 flex items-center justify-between gap-4">
-            <div>
-              <h1 className="text-[20px] lg:text-[24px] text-[#021034] font-[600]">
-                Welcome, {displayName}
-              </h1>
-              <p className="mt-1 text-[12px] lg:text-sm text-[#737373]">
-                View Your Attendance and Result updates.
-              </p>
-            </div>
+    <div className="p-6 bg-[#F5F9FF] min-h-full">
+      <section className="pl-2 mb-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-[20px] lg:text-[24px] text-[#021034] font-[600]">
+              Welcome, {displayName}
+            </h1>
+            <p className="mt-1 text-[12px] lg:text-sm text-[#737373]">
+              {formatClassLabel(currentClass)}
+              {dashboard?.profile?.studentCode
+                ? ` · ${dashboard.profile.studentCode}`
+                : ""}
+            </p>
           </div>
-        </section>
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 w-full">
-          <div className="col-span-2 border border-[#D7E3FC] grid rounded-xl bg-white w-full mr-6">
-            {schedule.length === 0 ? (
+          <Link
+            href="/student/profile"
+            className="inline-flex items-center gap-1 text-sm text-[#737373] hover:text-blue-600 transition"
+          >
+            View profile
+            <ChevronRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 w-full">
+        <div className="col-span-2 space-y-6">
+          <div className="rounded-xl border border-[#D7E3FC] bg-white overflow-hidden">
+            <div className="flex items-center justify-between px-6 py-4 border-b border-[#D7E3FC]">
+              <div className="flex items-center gap-2">
+                <Clock className="h-4 w-4 text-[#021034]" />
+                <h2 className="text-lg font-semibold text-[#021034]">
+                  Timetable preview
+                </h2>
+              </div>
+              <Link
+                href="/student/timetable"
+                className="text-sm text-[#737373] hover:text-blue-600 transition inline-flex items-center gap-1"
+              >
+                Full timetable
+                <ChevronRight className="h-4 w-4" />
+              </Link>
+            </div>
+            {timetable.length === 0 ? (
               <div className="px-6 py-10 text-sm text-slate-500 text-center">
-                No schedule available for today.
+                No timetable available yet.
               </div>
             ) : (
-              schedule.map((item, index) => (
+              timetable.slice(0, 6).map((item, index) => (
                 <div
-                  key={index}
-                  className="flex items-center justify-between px-[8px] py-[16px] lg:px-6 lg:py-6 border-b border-[#D7E3FC] last:border-b-0"
+                  key={`${item.subject}-${item.startTime}-${index}`}
+                  className="flex items-center justify-between px-[8px] py-[16px] lg:px-6 lg:py-4 border-b border-[#D7E3FC] last:border-b-0"
                 >
-                  <div className="space-y-2">
+                  <div className="space-y-1">
                     <p className="font-medium text-[#021034]">
-                      {String(item.subject ?? item.title ?? "Class")}
+                      {item.subject ?? "Class"}
                     </p>
-                    <div className="flex items-center gap-2 lg:gap-4 text-sm text-[#737373]">
-                      <div className="flex items-center gap-1">
-                        <span aria-hidden>⏱</span>
+                    <div className="flex flex-wrap items-center gap-2 lg:gap-4 text-sm text-[#737373]">
+                      <span>
+                        {item.startTime ?? "-"}
+                        {item.endTime ? `–${item.endTime}` : ""}
+                      </span>
+                      {(item.subjectTeacher ||
+                        item.teacher ||
+                        item.teacherName) && (
                         <span>
-                          {String(item.startTime ?? item.time ?? "-")}
-                          {item.endTime ? `–${String(item.endTime)}` : ""}
+                          {item.subjectTeacher ??
+                            item.teacher ??
+                            item.teacherName}
                         </span>
-                      </div>
-                      {item.teacher || item.teacherName ? (
-                        <div className="flex items-center gap-1">
-                          <span aria-hidden>👥</span>
-                          <span>
-                            {String(item.teacher ?? item.teacherName)}
-                          </span>
-                        </div>
-                      ) : null}
+                      )}
                     </div>
                   </div>
                   <div className="rounded-full border border-[#D7E3FC] bg-blue-50 px-4 py-1 text-xs font-semibold text-[#021034]">
-                    {String(item.room ?? item.location ?? "—")}
+                    {item.room ?? "—"}
                   </div>
                 </div>
               ))
             )}
           </div>
-          <div className="w-full max-w-full flex justify-center items-center">
-            <AttendanceSummary
-              presentDays={presentDays}
-              absentDays={absentDays}
-              monthlyPercentage={monthlyPercentage}
-            />
-          </div>
-        </div>
 
-        <div className="w-full min-w-full rounded-xl border border-[#D7E3FC] bg-white overflow-hidden mt-6">
-          <div className="flex items-start justify-between px-6 py-4">
-            <div>
-              <h2 className="text-lg font-semibold text-[#021034]">
-                Recent Updates
-              </h2>
-              <p className="text-sm text-[#737373]">
-                Check complete update at same time.
-              </p>
+          <div className="rounded-xl border border-[#D7E3FC] bg-white overflow-hidden">
+            <div className="flex items-start justify-between px-6 py-4">
+              <div className="flex items-start gap-2">
+                <Megaphone className="h-4 w-4 mt-1 text-[#021034]" />
+                <div>
+                  <h2 className="text-lg font-semibold text-[#021034]">
+                    Recent announcements
+                  </h2>
+                  <p className="text-sm text-[#737373]">
+                    Latest updates from your school and class.
+                  </p>
+                </div>
+              </div>
+              <Link
+                href="/student/announcements"
+                className="text-sm text-[#737373] hover:text-blue-600 transition inline-flex items-center gap-1"
+              >
+                View all
+                <ChevronRight className="h-4 w-4" />
+              </Link>
             </div>
-            <button
-              type="button"
-              className="text-sm text-[#737373] hover:text-blue-600 transition"
-            >
-              View all activity
-            </button>
-          </div>
-          <div className="border-t border-[#D7E3FC]" />
-          <div className="px-6 py-8 text-sm text-slate-500 text-center">
-            No recent updates yet.
+            <div className="border-t border-[#D7E3FC]" />
+            {announcements.length === 0 ? (
+              <div className="px-6 py-8 text-sm text-slate-500 text-center">
+                No announcements yet.
+              </div>
+            ) : (
+              <ul className="divide-y divide-[#D7E3FC]">
+                {announcements.map((a) => (
+                  <li key={a.id} className="px-6 py-4">
+                    <p className="font-medium text-[#021034]">{a.title}</p>
+                    <p className="mt-1 text-sm text-[#737373] line-clamp-2">
+                      {a.body}
+                    </p>
+                    <p className="mt-2 text-xs text-slate-400">
+                      {a.publishedAt
+                        ? new Date(a.publishedAt).toLocaleString()
+                        : ""}
+                      {a.authorName ? ` · ${a.authorName}` : ""}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         </div>
 
-        <DocumentsGrid />
+        <div className="w-full space-y-6">
+          <AttendanceSummary
+            presentDays={presentDays}
+            absentDays={absentDays}
+            monthlyPercentage={monthlyPercentage}
+          />
+
+          <div className="rounded-xl border border-[#D7E3FC] bg-white p-4">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <CalendarDays className="h-4 w-4 text-[#021034]" />
+                <h2 className="font-semibold text-[#021034]">Quick links</h2>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              {[
+                { href: "/student/fees", label: "Fees" },
+                { href: "/student/exams", label: "Exams" },
+                { href: "/student/homework", label: "Homework" },
+                { href: "/student/documents", label: "Documents" },
+              ].map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="rounded-lg border border-[#D7E3FC] bg-[#F5F9FF] px-3 py-3 text-center text-sm font-medium text-[#021034] hover:bg-blue-50 transition"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-2">
+        <div className="flex items-center justify-between mt-6 mb-[-8px] px-1 relative z-10">
+          <div className="flex items-center gap-2">
+            <FileText className="h-4 w-4 text-[#021034]" />
+            <span className="text-sm text-[#737373]">
+              {dashboard?.documents?.count ?? documentItems.length} document
+              {(dashboard?.documents?.count ?? documentItems.length) === 1
+                ? ""
+                : "s"}
+            </span>
+          </div>
+          <Link
+            href="/student/documents"
+            className="text-sm text-[#737373] hover:text-blue-600 transition inline-flex items-center gap-1"
+          >
+            All documents
+            <ChevronRight className="h-4 w-4" />
+          </Link>
+        </div>
+        {documentItems.length === 0 ? (
+          <div className="w-full rounded-xl border border-[#D7E3FC] bg-white p-8 mt-6 text-center text-sm text-slate-500">
+            No documents uploaded yet.
+          </div>
+        ) : (
+          <DocumentsGrid title="Recent documents" documents={documentItems} />
+        )}
       </div>
     </div>
   );

--- a/src/app/student/documents/page.tsx
+++ b/src/app/student/documents/page.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import React from "react";
+import { ExternalLink, FileText } from "lucide-react";
+import {
+  getStudentDocuments,
+  type StudentPortalDocument,
+} from "@/modules/students";
+import { ensureSessionReady } from "@/modules/auth";
+import { useToast } from "@/components/ui/use-toast";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { DataTableSkeleton } from "@/components/skeletons";
+import { DOCUMENT_TYPES } from "@/modules/documents/constants";
+
+function docTypeLabel(value: string): string {
+  return DOCUMENT_TYPES.find((t) => t.value === value)?.label ?? value;
+}
+
+function formatSize(size?: number | null): string {
+  if (size == null || !Number.isFinite(size)) return "—";
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default function StudentDocumentsPage() {
+  const [docs, setDocs] = React.useState<StudentPortalDocument[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const { toast } = useToast();
+  const toastRef = React.useRef(toast);
+
+  React.useEffect(() => {
+    toastRef.current = toast;
+  }, [toast]);
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await ensureSessionReady();
+      const data = await getStudentDocuments();
+      setDocs(data);
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Failed to load documents";
+      setError(message);
+      toastRef.current?.({
+        title: "Error",
+        description: message,
+        type: "error",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="mx-auto px-4 py-6">
+        <div className="mb-6 space-y-2">
+          <div className="h-7 w-40 animate-pulse rounded bg-slate-200" />
+          <div className="h-4 w-56 animate-pulse rounded bg-slate-100" />
+        </div>
+        <DataTableSkeleton
+          rows={5}
+          columns={[
+            { headerWidth: "w-40", cellWidth: "w-48" },
+            { headerWidth: "w-28", cellWidth: "w-32" },
+            { headerWidth: "w-20", cellWidth: "w-24" },
+            { headerWidth: "w-16", cellWidth: "w-20" },
+          ]}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto px-4 py-6 bg-[#F5F9FF] min-h-full">
+      <div className="mb-6 flex items-start gap-3">
+        <FileText className="mt-1 h-5 w-5 text-[#021034]" />
+        <div>
+          <h1 className="text-[24px] font-[600] text-[#021034]">Documents</h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            View documents linked to your student profile
+          </p>
+        </div>
+      </div>
+
+      {error ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-slate-700">{error}</p>
+            <Button variant="dark" onClick={() => void load()}>
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : docs.length === 0 ? (
+        <Card>
+          <p className="py-8 text-center text-sm text-slate-500">
+            No documents found. Contact the school office if you need something
+            uploaded.
+          </p>
+        </Card>
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-slate-500">
+                  <th className="py-2 pr-3">Name</th>
+                  <th className="py-2 pr-3">Type</th>
+                  <th className="hidden py-2 pr-3 md:table-cell">Size</th>
+                  <th className="py-2">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {docs.map((doc) => (
+                  <tr key={doc.id} className="border-t border-slate-100">
+                    <td className="py-3 pr-3 font-medium text-[#021034]">
+                      {doc.originalName || doc.fileName || "Document"}
+                    </td>
+                    <td className="py-3 pr-3">
+                      <span className="inline-block rounded-full border border-[#D7E3FC] bg-[#F5F9FF] px-2 py-0.5 text-xs font-medium text-[#021034]">
+                        {docTypeLabel(doc.documentType)}
+                      </span>
+                    </td>
+                    <td className="hidden py-3 pr-3 md:table-cell text-slate-600">
+                      {formatSize(doc.size)}
+                    </td>
+                    <td className="py-3">
+                      {doc.url ? (
+                        <a
+                          href={doc.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-blue-700 hover:underline"
+                        >
+                          View
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </a>
+                      ) : (
+                        <span className="text-slate-400">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/student/exams/page.tsx
+++ b/src/app/student/exams/page.tsx
@@ -1,27 +1,169 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
 import Card from "@/components/ui/Card";
 import { DataTableSkeleton } from "@/components/skeletons";
 import {
+  EXAM_STATUS_LABELS,
+  EXAM_TYPE_LABELS,
   formatPercent,
   useMyExamResults,
+  useMyExamSchedule,
+  type ExamStatus,
+  type ExamType,
 } from "@/modules/exams";
 
 export default function StudentExamsPage() {
-  const { data, isLoading, error, refetch } = useMyExamResults();
+  const [tab, setTab] = useState<"schedule" | "results">("schedule");
+  const results = useMyExamResults();
+  const schedule = useMyExamSchedule();
 
   return (
-    <div className="mx-auto px-4 py-6">
+    <div className="mx-auto px-4 py-6 bg-[#F5F9FF] min-h-full">
       <div className="mb-6">
         <h1 className="text-[24px] font-[600] text-[#021034]">My exams</h1>
         <p className="mt-1 text-[14px] text-[#737373]">
-          Published results and report cards
+          Upcoming schedule and published results
         </p>
       </div>
 
-      {isLoading ? (
+      <div className="mb-4 flex gap-2">
+        <button
+          type="button"
+          className={`rounded-md px-3 py-1.5 text-sm font-medium ${
+            tab === "schedule"
+              ? "bg-[#DBEAFE] text-[#021034]"
+              : "border border-slate-200 bg-white text-slate-600"
+          }`}
+          onClick={() => setTab("schedule")}
+        >
+          Schedule
+        </button>
+        <button
+          type="button"
+          className={`rounded-md px-3 py-1.5 text-sm font-medium ${
+            tab === "results"
+              ? "bg-[#DBEAFE] text-[#021034]"
+              : "border border-slate-200 bg-white text-slate-600"
+          }`}
+          onClick={() => setTab("results")}
+        >
+          Results
+        </button>
+      </div>
+
+      {tab === "schedule" ? (
+        schedule.isLoading ? (
+          <DataTableSkeleton
+            rows={6}
+            columns={[
+              { headerWidth: "w-32", cellWidth: "w-40" },
+              { headerWidth: "w-24", cellWidth: "w-28" },
+              { headerWidth: "w-20", cellWidth: "w-24" },
+              { headerWidth: "w-24", cellWidth: "w-28" },
+            ]}
+          />
+        ) : schedule.error ? (
+          <Card>
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-slate-700">Failed to load schedule.</p>
+              <Button variant="dark" onClick={() => void schedule.refetch()}>
+                Retry
+              </Button>
+            </div>
+          </Card>
+        ) : (schedule.data ?? []).length === 0 ? (
+          <Card>
+            <p className="py-8 text-center text-sm text-slate-500">
+              No exam schedule available yet.
+            </p>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {schedule.data!.map((group) => (
+              <Card key={group.exam.id}>
+                <div className="mb-3 flex flex-wrap items-center gap-2">
+                  <h2 className="text-base font-semibold text-[#021034]">
+                    {group.exam.name}
+                  </h2>
+                  {group.exam.examType ? (
+                    <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-800">
+                      {EXAM_TYPE_LABELS[group.exam.examType as ExamType] ??
+                        group.exam.examType}
+                    </span>
+                  ) : null}
+                  {group.exam.status ? (
+                    <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700">
+                      {EXAM_STATUS_LABELS[group.exam.status as ExamStatus] ??
+                        group.exam.status}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="min-w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-slate-500">
+                        <th className="py-2 pr-3">Subject</th>
+                        <th className="py-2 pr-3">Date</th>
+                        <th className="hidden py-2 pr-3 md:table-cell">Time</th>
+                        <th className="hidden py-2 pr-3 md:table-cell">
+                          Venue
+                        </th>
+                        <th className="py-2">Marks</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {group.schedules.length === 0 ? (
+                        <tr>
+                          <td
+                            colSpan={5}
+                            className="py-6 text-center text-slate-500"
+                          >
+                            No subjects scheduled
+                          </td>
+                        </tr>
+                      ) : (
+                        group.schedules.map((s) => (
+                          <tr
+                            key={s.id}
+                            className="border-t border-slate-100"
+                          >
+                            <td className="py-3 pr-3 font-medium text-[#021034]">
+                              {s.subjectName ?? "—"}
+                              {s.subjectCode ? (
+                                <span className="ml-1 text-xs text-slate-400">
+                                  ({s.subjectCode})
+                                </span>
+                              ) : null}
+                            </td>
+                            <td className="py-3 pr-3 whitespace-nowrap">
+                              {s.examDate?.slice(0, 10) ?? "—"}
+                            </td>
+                            <td className="hidden py-3 pr-3 md:table-cell whitespace-nowrap">
+                              {s.startTime ?? "—"}
+                              {s.endTime ? `–${s.endTime}` : ""}
+                            </td>
+                            <td className="hidden py-3 pr-3 md:table-cell">
+                              {s.venue ?? "—"}
+                            </td>
+                            <td className="py-3">
+                              {s.maxMarks != null
+                                ? `${s.passMarks ?? 0}/${s.maxMarks}`
+                                : "—"}
+                            </td>
+                          </tr>
+                        ))
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </Card>
+            ))}
+          </div>
+        )
+      ) : results.isLoading ? (
         <DataTableSkeleton
           rows={6}
           columns={[
@@ -31,11 +173,11 @@ export default function StudentExamsPage() {
             { headerWidth: "w-24", cellWidth: "w-28" },
           ]}
         />
-      ) : error ? (
+      ) : results.error ? (
         <Card>
           <div className="flex flex-col gap-3">
             <p className="text-sm text-slate-700">Failed to load results.</p>
-            <Button variant="dark" onClick={() => void refetch()}>
+            <Button variant="dark" onClick={() => void results.refetch()}>
               Retry
             </Button>
           </div>
@@ -54,14 +196,14 @@ export default function StudentExamsPage() {
                 </tr>
               </thead>
               <tbody>
-                {(data ?? []).length === 0 ? (
+                {(results.data ?? []).length === 0 ? (
                   <tr>
                     <td colSpan={5} className="py-8 text-center text-slate-500">
                       No published results yet.
                     </td>
                   </tr>
                 ) : (
-                  data!.map((r) => (
+                  results.data!.map((r) => (
                     <tr key={r.id} className="border-t border-slate-100">
                       <td className="py-3 pr-3 font-medium text-[#021034]">
                         {r.examName}

--- a/src/app/student/fees/page.tsx
+++ b/src/app/student/fees/page.tsx
@@ -8,6 +8,7 @@ import { useToast } from "@/components/ui/use-toast";
 import {
   useMyFees,
   useMyFeePayments,
+  useMyFeesSummary,
   downloadMyReceipt,
   formatInr,
   FEE_STATUS_LABELS,
@@ -18,11 +19,12 @@ import {
 export default function StudentFeesPage() {
   const { toast } = useToast();
   const [tab, setTab] = useState<"dues" | "history">("dues");
+  const summary = useMyFeesSummary();
   const fees = useMyFees({ page: 1, limit: 50 });
   const payments = useMyFeePayments({ page: 1, limit: 50 });
 
   return (
-    <div className="mx-auto px-4 py-6">
+    <div className="mx-auto px-4 py-6 bg-[#F5F9FF] min-h-full">
       <div className="mb-4">
         <h1 className="text-[24px] font-[600] text-[#021034]">My Fees</h1>
         <p className="mt-1 text-[14px] text-[#737373]">
@@ -30,8 +32,48 @@ export default function StudentFeesPage() {
         </p>
       </div>
 
+      {summary.isLoading ? (
+        <div className="mb-4 grid grid-cols-2 gap-3 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-20 animate-pulse rounded-xl border border-[#D7E3FC] bg-white"
+            />
+          ))}
+        </div>
+      ) : summary.data ? (
+        <div className="mb-4 grid grid-cols-2 gap-3 md:grid-cols-4">
+          {[
+            {
+              label: "Outstanding",
+              value: formatInr(summary.data.totalOutstanding),
+            },
+            { label: "Paid", value: formatInr(summary.data.totalPaid) },
+            {
+              label: "Pending",
+              value: String(summary.data.pendingCount),
+            },
+            {
+              label: "Overdue",
+              value: String(summary.data.overdueCount),
+            },
+          ].map((stat) => (
+            <div
+              key={stat.label}
+              className="rounded-xl border border-[#D7E3FC] bg-white px-4 py-3"
+            >
+              <p className="text-xs text-[#737373]">{stat.label}</p>
+              <p className="mt-1 text-lg font-semibold text-[#021034]">
+                {stat.value}
+              </p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
       <div className="mb-4 flex gap-2">
         <button
+          type="button"
           className={`rounded-md px-3 py-1.5 text-sm font-medium ${
             tab === "dues"
               ? "bg-[#DBEAFE] text-[#021034]"
@@ -42,6 +84,7 @@ export default function StudentFeesPage() {
           Dues
         </button>
         <button
+          type="button"
           className={`rounded-md px-3 py-1.5 text-sm font-medium ${
             tab === "history"
               ? "bg-[#DBEAFE] text-[#021034]"
@@ -176,6 +219,7 @@ export default function StudentFeesPage() {
                       </td>
                       <td className="py-3">
                         <button
+                          type="button"
                           className="text-blue-700 hover:underline"
                           onClick={async () => {
                             try {

--- a/src/app/student/profile/page.tsx
+++ b/src/app/student/profile/page.tsx
@@ -1,53 +1,107 @@
 "use client";
+
 import React from "react";
-import { getStudentProfile, StudentPortalProfileSkeleton } from "@/modules/students";
-import { Card } from "../../../components/ui/Card";
 import Image from "next/image";
+import {
+  getStudentProfile,
+  StudentPortalProfileSkeleton,
+} from "@/modules/students";
+import { Card } from "../../../components/ui/Card";
 import { ensureSessionReady } from "@/modules/auth";
 import DocumentsGrid from "@/modules/documents/components/DocumentsGrid";
 import InfoField from "@/components/profile/InfoField";
+import Button from "@/components/ui/Button";
+import { DOCUMENT_TYPES } from "@/modules/documents/constants";
+
+function docTypeLabel(value: string): string {
+  return DOCUMENT_TYPES.find((t) => t.value === value)?.label ?? value;
+}
+
+function formatClass(
+  cls?: { name?: string; section?: string | null } | null,
+): string {
+  if (!cls?.name) return "Not Assigned";
+  return cls.section ? `${cls.name} - ${cls.section}` : cls.name;
+}
 
 export default function StudentProfilePage() {
-  const [me, setMe] = React.useState<any>(null);
+  const [me, setMe] = React.useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await ensureSessionReady();
+      const data = await getStudentProfile();
+      setMe(data as Record<string, unknown>);
+    } catch (err: unknown) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load profile",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   React.useEffect(() => {
-    let mounted = true;
-    async function load() {
-      try {
-        await ensureSessionReady();
-        if (!mounted) return;
-        const data = await getStudentProfile();
-        if (!mounted) return;
-        setMe(data);
-      } finally {
-        if (mounted) setLoading(false);
-      }
-    }
-    load();
-    return () => {
-      mounted = false;
-    };
-  }, []);
+    void load();
+  }, [load]);
 
   if (loading) return <StudentPortalProfileSkeleton />;
 
+  if (error && !me) {
+    return (
+      <div className="p-6">
+        <div className="rounded-xl border border-[#D7E3FC] bg-white p-8 text-center">
+          <p className="mb-4 text-sm text-slate-700">{error}</p>
+          <Button variant="dark" onClick={() => void load()}>
+            Retry
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const cls = me?.class as
+    | { name?: string; section?: string | null }
+    | null
+    | undefined;
+  const documents = Array.isArray(me?.documents)
+    ? (me!.documents as Array<Record<string, unknown>>)
+    : [];
+
+  const documentItems = documents.map((doc) => ({
+    id: String(doc.id ?? doc.url ?? Math.random()),
+    title: String(
+      doc.originalName ||
+        doc.fileName ||
+        docTypeLabel(String(doc.documentType ?? "OTHER")),
+    ),
+    type: docTypeLabel(String(doc.documentType ?? "OTHER")),
+    href: typeof doc.url === "string" ? doc.url : undefined,
+  }));
+
   return (
-    <div className="p-3 md:p-6 ">
+    <div className="p-3 md:p-6 bg-[#F5F9FF] min-h-full">
       <div className="mb-6 flex items-center justify-between gap-4">
         <div>
           <h1 className="text-[20px] lg:text-[24px] font-[600] text-[#021034]">
-            Total Students
+            My Profile
           </h1>
           <p className="mt-1 text-[13px] lg:text-[14px] text-[#737373]">
-            Manage, Student Profiles, status and Enrollment
+            View your personal, academic, and guardian details
           </p>
         </div>
       </div>
       <Card className="flex items-center gap-6 mb-[20px]">
         <div className="bg-slate-400 rounded-full overflow-hidden w-[62px] h-[62px] items-center flex-shrink-0">
           <Image
-            src={me?.photoUrl || "/images/avatar.png"}
+            src={
+              (typeof me?.photoUrl === "string" && me.photoUrl) ||
+              "/images/avatar.png"
+            }
             alt="avatar"
             width={62}
             height={62}
@@ -56,69 +110,103 @@ export default function StudentProfilePage() {
         </div>
         <div className="flex-1 gap-2 flex flex-col">
           <div className="text-[20px] lg:text-[24px] font-[600] text-[#021034]">
-            {me?.fullName ?? "-"}
+            {(me?.fullName as string) ?? (me?.name as string) ?? "-"}
           </div>
           <div className="text-[13px] lg:text-[14px] font-[400] text-[#737373]">
             Student ID:{" "}
-            <span className="text-[#021034]">{me?.id ?? "-"}</span>
+            <span className="text-[#021034]">
+              {(me?.studentCode as string) ?? (me?.id as string) ?? "-"}
+            </span>
           </div>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <p className="text-[8px] lg:text-[10px] font-[600] py-[3px] px-2 border rounded-full border-[#D7E3FC] bg-[#F5F9FF]">
-              {me?.class?.name
-                ? `${me.class.name}${
-                    me.class.section ? " - " + me.class.section : ""
-                  }`
-                : "Not Assigned"}
+              {formatClass(cls)}
             </p>
-            <p className="text-[8px] lg:text-[10px] font-[600] py-[3px] px-2 flex items-center justify-center  rounded-full bg-[#DBEAFF] text-[#1E3A8A]">
-              {me?.stream ?? "Not Assigned"}
-            </p>
-            <p className="text-[8px] lg:text-[10px] font-[600] py-[3px] px-2 flex items-center justify-center  rounded-full bg-[#F4E8FF] text-[#6930B3]">
-              {me?.session ?? "2026-27"}
-            </p>
-            <p className="text-[8px] lg:text-[10px] font-[600] py-[3px] px-2 flex items-center justify-center  rounded-full bg-[#DCFCE6] text-[#16A34A]">
-              {me?.status ?? "N/A"}
-            </p>
+            {(me?.status as string) ? (
+              <p className="text-[8px] lg:text-[10px] font-[600] py-[3px] px-2 flex items-center justify-center rounded-full bg-[#DCFCE6] text-[#16A34A]">
+                {String(me?.status)}
+              </p>
+            ) : null}
           </div>
         </div>
       </Card>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-[20px]">
         <div className="w-full max-w-full bg-white rounded-xl border border-blue-200 p-[16px]">
-          {/* Title */}
           <h2 className="text-[16px] lg:text-[20px] font-semibold text-gray-900 mb-5">
             Personal Information
           </h2>
 
-          {/* Grid */}
           <div className="grid grid-cols-2 md:grid-cols-2 gap-4">
-            <InfoField label="Full Name" value={me?.name ?? "-"} />
-            <InfoField label="Date of Birth" value={me?.dob ?? "-"} />
-            <InfoField label="Gender" value={me?.gender ?? "-"} />
-            <InfoField label="Blood Group" value={me?.bloodGroup ?? "-"} />
-            <InfoField label="Category" value={me?.category ?? "-"} />
-            <InfoField label="Aadhaar Number" value={me?.aadhaar ?? "-"} />
-            <InfoField label="Phone No." value={me?.phone ?? "-"} />
-            <InfoField label="Email Address" value={me?.email ?? "-"} />
+            <InfoField
+              label="Full Name"
+              value={
+                (me?.fullName as string) ?? (me?.name as string) ?? "-"
+              }
+            />
+            <InfoField
+              label="Date of Birth"
+              value={
+                me?.dob
+                  ? String(me.dob).slice(0, 10)
+                  : "-"
+              }
+            />
+            <InfoField label="Gender" value={(me?.gender as string) ?? "-"} />
+            <InfoField
+              label="Blood Group"
+              value={(me?.bloodGroup as string) ?? "-"}
+            />
+            <InfoField
+              label="Aadhaar Number"
+              value={
+                (me?.aadhaarNumber as string) ??
+                (me?.aadhaar as string) ??
+                "-"
+              }
+            />
+            <InfoField
+              label="Phone No."
+              value={
+                (me?.phoneNumber as string) ?? (me?.phone as string) ?? "-"
+              }
+            />
+            <InfoField
+              label="Email Address"
+              value={(me?.email as string) ?? "-"}
+            />
             <div className="col-span-2">
-              <InfoField label="Address" value={me?.address ?? "-"} />
+              <InfoField
+                label="Address"
+                value={(me?.address as string) ?? "-"}
+              />
             </div>
           </div>
         </div>
 
         <div className="w-full max-w-full bg-white rounded-xl border border-blue-200 p-[16px]">
-          {/* Title */}
           <h2 className="text-lg lg:text-[20px] font-semibold text-gray-900 mb-5">
             Parent / Guardian Information
           </h2>
 
-          {/* Grid */}
           <div className="grid grid-cols-2 lg:grid-cols-1 gap-4">
             <div className="border border-blue-200 rounded-lg p-3 bg-blue-50">
               <p className="text-xs lg:text-sm text-gray-500 mb-1">
                 Father Name
               </p>
               <p className="text-[11px] lg:text-[14px] font-[500] text-gray-900">
-                {me?.guardian?.fatherName ?? "-"}
+                {(me?.fatherName as string) ??
+                  ((me?.guardian as { fatherName?: string } | undefined)
+                    ?.fatherName) ??
+                  "-"}
+              </p>
+            </div>
+
+            <div className="border border-blue-200 rounded-lg p-3 bg-blue-50">
+              <p className="text-xs lg:text-sm text-gray-500 mb-1">
+                Father Mobile
+              </p>
+              <p className="text-[11px] lg:text-[14px] font-[500] text-gray-900">
+                {(me?.fatherMobile as string) ?? "-"}
               </p>
             </div>
 
@@ -127,43 +215,54 @@ export default function StudentProfilePage() {
                 Mother Name
               </p>
               <p className="text-[11px] lg:text-[14px] font-[500] text-gray-900">
-                {me?.guardian?.motherName ?? "-"}
+                {(me?.motherName as string) ??
+                  ((me?.guardian as { motherName?: string } | undefined)
+                    ?.motherName) ??
+                  "-"}
               </p>
             </div>
 
             <div className="border border-blue-200 rounded-lg p-3 bg-blue-50">
               <p className="text-xs lg:text-sm text-gray-500 mb-1">
-                Parent Contact
+                Mother Mobile
               </p>
               <p className="text-[11px] lg:text-[14px] font-[500] text-gray-900">
-                {me?.guardian?.phone ?? "-"}
+                {(me?.motherMobile as string) ??
+                  ((me?.guardian as { phone?: string } | undefined)?.phone) ??
+                  "-"}
               </p>
             </div>
 
             <div className="border border-blue-200 rounded-lg p-3 bg-blue-50">
               <p className="text-xs lg:text-sm text-gray-500 mb-1">
-                Parent Mail
+                Guardian Name
               </p>
               <p className="text-[11px] lg:text-[14px] font-[500] text-gray-900">
-                {me?.guardian?.email ?? "-"}
+                {(me?.guardianName as string) ?? "-"}
               </p>
             </div>
-          </div>
-          {/* Address (Full Width) */}
-          <div className="c border border-blue-200 rounded-lg p-3 bg-blue-50 mt-4">
-            <p className="text-xs lg:text-sm text-gray-500 mb-1">
-              Local Address
-            </p>
-            <p className="text-[11px] lg:text-[14px] font-[500] text-gray-900">
-              {me?.guardian?.localAddress ?? me?.address ?? "-"}
-            </p>
+
+            <div className="border border-blue-200 rounded-lg p-3 bg-blue-50">
+              <p className="text-xs lg:text-sm text-gray-500 mb-1">
+                Guardian Mobile
+              </p>
+              <p className="text-[11px] lg:text-[14px] font-[500] text-gray-900">
+                {(me?.guardianMobile as string) ?? "-"}
+              </p>
+            </div>
           </div>
         </div>
       </div>
 
-      <DocumentsGrid />
+      {documentItems.length === 0 ? (
+        <div className="w-full rounded-xl border border-[#D7E3FC] bg-white p-8 mt-6 text-center text-sm text-slate-500">
+          No documents on file.
+        </div>
+      ) : (
+        <DocumentsGrid documents={documentItems} />
+      )}
       <div className="flex w-full p-3 md:p-6">
-        <p className="texr-[10px] text-[#737373] font-[600] text-center mx-auto">
+        <p className="text-[10px] text-[#737373] font-[600] text-center mx-auto">
           If any information is incorrect, please contact the school office for
           assistance.
         </p>

--- a/src/app/student/timetable/page.tsx
+++ b/src/app/student/timetable/page.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import React from "react";
+import { CalendarDays } from "lucide-react";
+import {
+  getTimetable,
+  type StudentTimetableItem,
+} from "@/modules/students";
+import { ensureSessionReady } from "@/modules/auth";
+import { useToast } from "@/components/ui/use-toast";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { DataTableSkeleton } from "@/components/skeletons";
+
+const DAY_LABELS: Record<number, string> = {
+  1: "Monday",
+  2: "Tuesday",
+  3: "Wednesday",
+  4: "Thursday",
+  5: "Friday",
+  6: "Saturday",
+  7: "Sunday",
+  0: "Sunday",
+};
+
+function teacherName(item: StudentTimetableItem): string {
+  return (
+    item.subjectTeacher ?? item.teacher ?? item.teacherName ?? "—"
+  );
+}
+
+export default function StudentTimetablePage() {
+  const [items, setItems] = React.useState<StudentTimetableItem[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const { toast } = useToast();
+  const toastRef = React.useRef(toast);
+
+  React.useEffect(() => {
+    toastRef.current = toast;
+  }, [toast]);
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await ensureSessionReady();
+      const data = await getTimetable();
+      setItems(data);
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Failed to load timetable";
+      setError(message);
+      toastRef.current?.({
+        title: "Error",
+        description: message,
+        type: "error",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  const hasDay = items.some(
+    (i) => typeof i.dayOfWeek === "number" && Number.isFinite(i.dayOfWeek),
+  );
+
+  const grouped = React.useMemo(() => {
+    if (!hasDay) return null;
+    const map = new Map<number, StudentTimetableItem[]>();
+    for (const item of items) {
+      const day = typeof item.dayOfWeek === "number" ? item.dayOfWeek : -1;
+      if (!map.has(day)) map.set(day, []);
+      map.get(day)!.push(item);
+    }
+    return [...map.entries()].sort(([a], [b]) => a - b);
+  }, [items, hasDay]);
+
+  if (loading) {
+    return (
+      <div className="mx-auto px-4 py-6">
+        <div className="mb-6 space-y-2">
+          <div className="h-7 w-40 animate-pulse rounded bg-slate-200" />
+          <div className="h-4 w-64 animate-pulse rounded bg-slate-100" />
+        </div>
+        <DataTableSkeleton
+          rows={8}
+          columns={[
+            { headerWidth: "w-24", cellWidth: "w-28" },
+            { headerWidth: "w-32", cellWidth: "w-40" },
+            { headerWidth: "w-28", cellWidth: "w-32" },
+            { headerWidth: "w-20", cellWidth: "w-24" },
+          ]}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto px-4 py-6 bg-[#F5F9FF] min-h-full">
+      <div className="mb-6 flex items-start gap-3">
+        <CalendarDays className="mt-1 h-5 w-5 text-[#021034]" />
+        <div>
+          <h1 className="text-[24px] font-[600] text-[#021034]">Timetable</h1>
+          <p className="mt-1 text-[14px] text-[#737373]">
+            Your weekly class schedule
+          </p>
+        </div>
+      </div>
+
+      {error ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-slate-700">{error}</p>
+            <Button variant="dark" onClick={() => void load()}>
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : items.length === 0 ? (
+        <Card>
+          <p className="py-8 text-center text-sm text-slate-500">
+            No timetable entries yet. Check back once your class schedule is
+            published.
+          </p>
+        </Card>
+      ) : grouped ? (
+        <div className="space-y-4">
+          {grouped.map(([day, rows]) => (
+            <Card key={day}>
+              <h2 className="mb-3 text-base font-semibold text-[#021034]">
+                {DAY_LABELS[day] ?? `Day ${day}`}
+              </h2>
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-slate-500">
+                      <th className="py-2 pr-3">Time</th>
+                      <th className="py-2 pr-3">Subject</th>
+                      <th className="hidden py-2 pr-3 md:table-cell">Teacher</th>
+                      <th className="py-2">Room</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rows.map((row, idx) => (
+                      <tr
+                        key={`${day}-${row.subject}-${row.startTime}-${idx}`}
+                        className="border-t border-slate-100"
+                      >
+                        <td className="py-3 pr-3 whitespace-nowrap text-[#021034]">
+                          {row.startTime ?? "—"}
+                          {row.endTime ? `–${row.endTime}` : ""}
+                        </td>
+                        <td className="py-3 pr-3 font-medium text-[#021034]">
+                          {row.subject ?? "—"}
+                        </td>
+                        <td className="hidden py-3 pr-3 md:table-cell text-slate-600">
+                          {teacherName(row)}
+                        </td>
+                        <td className="py-3 text-slate-600">{row.room ?? "—"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-slate-500">
+                  <th className="py-2 pr-3">Time</th>
+                  <th className="py-2 pr-3">Subject</th>
+                  <th className="hidden py-2 pr-3 md:table-cell">Teacher</th>
+                  <th className="py-2">Room</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((row, idx) => (
+                  <tr
+                    key={`${row.subject}-${row.startTime}-${idx}`}
+                    className="border-t border-slate-100"
+                  >
+                    <td className="py-3 pr-3 whitespace-nowrap text-[#021034]">
+                      {row.startTime ?? "—"}
+                      {row.endTime ? `–${row.endTime}` : ""}
+                    </td>
+                    <td className="py-3 pr-3 font-medium text-[#021034]">
+                      {row.subject ?? "—"}
+                    </td>
+                    <td className="hidden py-3 pr-3 md:table-cell text-slate-600">
+                      {teacherName(row)}
+                    </td>
+                    <td className="py-3 text-slate-600">{row.room ?? "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
-import { adminNav, studentNav, teacherNav, managementNav } from "./navConfig";
+import { adminNav, studentNav, teacherNav, managementNav, parentNav } from "./navConfig";
 import { useState } from "react";
 import { Settings, HeartHandshake, PanelRight } from "lucide-react";
 import { getUser } from "@/modules/auth";
@@ -32,6 +32,8 @@ export default function Navbar() {
     navItems = teacherNav;
   } else if (pathname.startsWith("/student")) {
     navItems = studentNav;
+  } else if (pathname.startsWith("/parent")) {
+    navItems = parentNav;
   } else {
     return null;
   }
@@ -74,6 +76,7 @@ export default function Navbar() {
                   (item.href !== "/admin/dashboard" &&
                     item.href !== "/teacher/dashboard" &&
                     item.href !== "/student/dashboard" &&
+                    item.href !== "/parent/dashboard" &&
                     pathname.startsWith(item.href));
                 return (
                   <Link key={item.href} href={item.href}>

--- a/src/components/layout/navConfig.ts
+++ b/src/components/layout/navConfig.ts
@@ -1,6 +1,7 @@
 import {
   LayoutDashboard,
   Users,
+  UsersRound,
   GraduationCap,
   School,
   IndianRupee,
@@ -8,6 +9,11 @@ import {
   BookOpen,
   FileMinus,
   ClipboardList,
+  CalendarDays,
+  Megaphone,
+  FileText,
+  KeyRound,
+  UserCircle,
 } from "lucide-react";
 
 export const adminNav = [
@@ -25,6 +31,11 @@ export const adminNav = [
     label: "Students",
     href: "/admin/students",
     icon: GraduationCap,
+  },
+  {
+    label: "Parents",
+    href: "/admin/parents",
+    icon: UsersRound,
   },
   {
     label: "Classes",
@@ -108,7 +119,27 @@ export const studentNav = [
   {
     label: "My Profile",
     href: "/student/profile",
-    icon: GraduationCap,
+    icon: UserCircle,
+  },
+  {
+    label: "Attendance",
+    href: "/student/attendance",
+    icon: ClipboardCheck,
+  },
+  {
+    label: "Timetable",
+    href: "/student/timetable",
+    icon: CalendarDays,
+  },
+  {
+    label: "Announcements",
+    href: "/student/announcements",
+    icon: Megaphone,
+  },
+  {
+    label: "Documents",
+    href: "/student/documents",
+    icon: FileText,
   },
   {
     label: "My Homework",
@@ -124,5 +155,23 @@ export const studentNav = [
     label: "My Fees",
     href: "/student/fees",
     icon: IndianRupee,
+  },
+  {
+    label: "Change Password",
+    href: "/student/change-password",
+    icon: KeyRound,
+  },
+];
+
+export const parentNav = [
+  {
+    label: "Dashboard",
+    href: "/parent/dashboard",
+    icon: LayoutDashboard,
+  },
+  {
+    label: "My Children",
+    href: "/parent/children",
+    icon: GraduationCap,
   },
 ];

--- a/src/config/api-routes.ts
+++ b/src/config/api-routes.ts
@@ -24,6 +24,11 @@ export const ADMIN_API = {
   DASHBOARD: "/admin/dashboard",
   STUDENTS: "/admin/students",
   TEACHERS: "/admin/teachers",
+  PARENTS: "/admin/parents",
+  PARENT_BY_ID: (id: string) => `/admin/parents/${id}`,
+  PARENT_CHILDREN: (id: string) => `/admin/parents/${id}/children`,
+  PARENT_UNLINK_CHILD: (id: string, studentId: string) =>
+    `/admin/parents/${id}/children/${studentId}`,
   CLASSES: "/admin/classes",
   CLASSES_WITH_TEACHER: "/admin/classes/with-class-teacher",
   SUBJECTS: "/admin/subjects",
@@ -97,22 +102,54 @@ export const ATTENDANCE_API = {
 };
 
 export const STUDENT_API = {
-  ME: "/api/student/me",
-  PROFILE: "/api/student/profile",
-  ATTENDANCE: "/api/student/attendance",
-  CHANGE_PASSWORD: "/api/student/auth/change-password",
+  ME: "/student/me",
+  PROFILE: "/student/profile",
+  ATTENDANCE: "/student/attendance",
+  CHANGE_PASSWORD: "/auth/change-password",
   /** Admin-facing student profile by id */
   BY_ID: (id: string) => `/admin/students/${id}`,
   /** Update student (admin or class teacher) */
   UPDATE: (id: string) => `/students/${id}`,
+  DASHBOARD: "/student/dashboard",
+  TIMETABLE: "/student/timetable",
+  DOCUMENTS: "/student/documents",
+  DOCUMENTS_UPLOAD: "/student/documents/upload",
+  ANNOUNCEMENTS: "/student/class/announcements",
+  ATTENDANCE_MONTHLY: "/student/attendance/monthly",
   HOMEWORK: "/student/homework",
   HOMEWORK_BY_ID: (id: string) => `/student/homework/${id}`,
   HOMEWORK_SUBMIT: (id: string) => `/student/homework/${id}/submissions`,
   EXAMS: "/student/exams",
   EXAM_REPORT_CARD: (examId: string) => `/student/exams/${examId}/report-card`,
   FEES: "/student/fees",
+  FEES_SUMMARY: "/student/fees/summary",
   FEE_PAYMENTS: "/student/fees/payments",
   FEE_PAYMENT_RECEIPT: (id: string) => `/student/fees/payments/${id}/receipt`,
+  EXAMS_SCHEDULE: "/student/exams/schedule",
+};
+
+export const PARENT_API = {
+  ME: "/parent/me",
+  CHILDREN: "/parent/children",
+  CHILD_DASHBOARD: (id: string) => `/parent/children/${id}/dashboard`,
+  CHILD_PROFILE: (id: string) => `/parent/children/${id}/profile`,
+  CHILD_ATTENDANCE: (id: string) => `/parent/children/${id}/attendance`,
+  CHILD_ATTENDANCE_MONTHLY: (id: string) =>
+    `/parent/children/${id}/attendance/monthly`,
+  CHILD_CLASS: (id: string) => `/parent/children/${id}/class`,
+  CHILD_TIMETABLE: (id: string) => `/parent/children/${id}/timetable`,
+  CHILD_ANNOUNCEMENTS: (id: string) => `/parent/children/${id}/announcements`,
+  CHILD_DOCUMENTS: (id: string) => `/parent/children/${id}/documents`,
+  CHILD_HOMEWORK: (id: string) => `/parent/children/${id}/homework`,
+  CHILD_HOMEWORK_BY_ID: (id: string, hwId: string) =>
+    `/parent/children/${id}/homework/${hwId}`,
+  CHILD_FEES: (id: string) => `/parent/children/${id}/fees`,
+  CHILD_FEES_SUMMARY: (id: string) => `/parent/children/${id}/fees/summary`,
+  CHILD_FEE_PAYMENTS: (id: string) => `/parent/children/${id}/fees/payments`,
+  CHILD_EXAMS: (id: string) => `/parent/children/${id}/exams`,
+  CHILD_EXAMS_SCHEDULE: (id: string) => `/parent/children/${id}/exams/schedule`,
+  CHILD_REPORT_CARD: (id: string, examId: string) =>
+    `/parent/children/${id}/exams/${examId}/report-card`,
 };
 
 const routes = {
@@ -123,6 +160,7 @@ const routes = {
   ADMIN_API,
   TEACHER_API,
   STUDENT_API,
+  PARENT_API,
 };
 
 export default routes;

--- a/src/config/loginConfig.ts
+++ b/src/config/loginConfig.ts
@@ -70,6 +70,13 @@ export const loginConfig: Record<
     redirectPath: "/student/dashboard",
     title: "Student Portal",
   },
+  parent: {
+    schema: loginSchema,
+    submit: authServices.parentLogin,
+    fields: sharedLoginFields,
+    redirectPath: "/parent/dashboard",
+    title: "Parent Portal",
+  },
 };
 
 export default loginConfig;

--- a/src/lib/roleFromPath.ts
+++ b/src/lib/roleFromPath.ts
@@ -6,5 +6,6 @@ export function roleFromPath(pathname: string | null | undefined): Role | null {
   if (pathname.startsWith("/admin")) return "admin";
   if (pathname.startsWith("/teacher")) return "teacher";
   if (pathname.startsWith("/student")) return "student";
+  if (pathname.startsWith("/parent")) return "parent";
   return null;
 }

--- a/src/modules/auth/api/authServices.ts
+++ b/src/modules/auth/api/authServices.ts
@@ -46,7 +46,11 @@ function handleLoginResponse(role: Role, data: unknown) {
     }
 
     const respUser =
-      payload.user ?? payload.teacher ?? payload.student ?? payload;
+      payload.user ??
+      payload.teacher ??
+      payload.student ??
+      payload.parent ??
+      payload;
     const user =
       respUser && typeof respUser === "object"
         ? normalizeUser(respUser as Record<string, unknown>, role)
@@ -99,9 +103,17 @@ export async function studentLogin(values: {
   return login("student", values);
 }
 
+export async function parentLogin(values: {
+  email: string;
+  password: string;
+}) {
+  return login("parent", values);
+}
+
 export default {
   login,
   adminLogin,
   teacherLogin,
   studentLogin,
+  parentLogin,
 };

--- a/src/modules/auth/api/session.ts
+++ b/src/modules/auth/api/session.ts
@@ -4,7 +4,7 @@ export type { Role };
 
 const PREFIX = "sc:auth";
 const ACTIVE_ROLE_KEY = `${PREFIX}:activeRole`;
-const ROLES: Role[] = ["admin", "teacher", "student"];
+const ROLES: Role[] = ["admin", "teacher", "student", "parent"];
 
 /** Access token lives in memory only (not localStorage). */
 let accessToken: string | null = null;
@@ -58,7 +58,12 @@ export function setAccessToken(token: string | null) {
 export function getActiveRole(): Role | null {
   try {
     const role = localStorage.getItem(ACTIVE_ROLE_KEY);
-    if (role === "admin" || role === "teacher" || role === "student") {
+    if (
+      role === "admin" ||
+      role === "teacher" ||
+      role === "student" ||
+      role === "parent"
+    ) {
       return role;
     }
     return null;

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -4,6 +4,7 @@ export {
   adminLogin,
   teacherLogin,
   studentLogin,
+  parentLogin,
 } from "./api/authServices";
 export { default as authServices } from "./api/authServices";
 export { loginSchema, type LoginSchema } from "./schemas/loginSchema";

--- a/src/modules/dashboard/components/student/AttendanceSummary.tsx
+++ b/src/modules/dashboard/components/student/AttendanceSummary.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import Link from "next/link";
 import { PieChart, Pie, Label } from "recharts";
 
 type AttendanceSummaryProps = {
@@ -15,11 +16,12 @@ export default function AttendanceSummary({
   monthlyPercentage,
 }: AttendanceSummaryProps) {
   const total = presentDays + absentDays;
-  const percentage = ((presentDays / total) * 100).toFixed(1);
+  const percentage =
+    total > 0 ? ((presentDays / total) * 100).toFixed(1) : "0.0";
 
   const data = [
-    { name: "Present", value: presentDays, fill: "#2ca02c" },
-    { name: "Absent", value: absentDays, fill: "#d62728" },
+    { name: "Present", value: presentDays || 0, fill: "#2ca02c" },
+    { name: "Absent", value: absentDays || 0, fill: "#d62728" },
   ];
 
   return (
@@ -28,7 +30,9 @@ export default function AttendanceSummary({
         <h2 className="text-lg font-semibold text-[#021034]">
           Attendance Summary
         </h2>
-        <span className="text-[#737373]">📅</span>
+        <span className="text-[#737373]" aria-hidden>
+          📅
+        </span>
       </div>
 
       <div className="flex justify-center py-6">
@@ -47,8 +51,8 @@ export default function AttendanceSummary({
                 let cy: number;
 
                 if ("cx" in viewBox && "cy" in viewBox) {
-                  cx = viewBox.cx;
-                  cy = viewBox.cy;
+                  cx = viewBox.cx as number;
+                  cy = viewBox.cy as number;
                 } else {
                   cx = viewBox.x + viewBox.width / 2;
                   cy = viewBox.y + viewBox.height / 2;
@@ -101,9 +105,12 @@ export default function AttendanceSummary({
           This Month : {monthlyPercentage}%
         </div>
 
-        <button className="w-full rounded-md border border-[#D7E3FC] py-2 text-sm font-medium text-[#021034] hover:bg-blue-50 transition">
+        <Link
+          href="/student/attendance"
+          className="block w-full rounded-md border border-[#D7E3FC] py-2 text-center text-sm font-medium text-[#021034] hover:bg-blue-50 transition"
+        >
           View Full Attendance
-        </button>
+        </Link>
       </div>
     </div>
   );

--- a/src/modules/exams/api/exams.ts
+++ b/src/modules/exams/api/exams.ts
@@ -13,6 +13,7 @@ import type {
   ExamStatus,
   Paginated,
   ReportCard,
+  StudentExamScheduleGroup,
   UpsertMarkItem,
 } from "@/modules/exams/types";
 
@@ -170,4 +171,11 @@ export async function fetchMyExamResults(): Promise<ExamResult[]> {
 export async function fetchMyReportCard(examId: string): Promise<ReportCard> {
   const res = await API.get<ReportCard>(STUDENT_API.EXAM_REPORT_CARD(examId));
   return res.data;
+}
+
+export async function fetchMyExamSchedule(): Promise<StudentExamScheduleGroup[]> {
+  const res = await API.get<StudentExamScheduleGroup[]>(
+    STUDENT_API.EXAMS_SCHEDULE,
+  );
+  return Array.isArray(res.data) ? res.data : [];
 }

--- a/src/modules/exams/constants/query-keys.ts
+++ b/src/modules/exams/constants/query-keys.ts
@@ -16,6 +16,7 @@ export const examQueryKeys = {
   classReport: (examId: string) =>
     [...examQueryKeys.all, "class-report", examId] as const,
   studentList: () => [...examQueryKeys.all, "student-list"] as const,
+  studentSchedule: () => [...examQueryKeys.all, "student-schedule"] as const,
   studentReportCard: (examId: string) =>
     [...examQueryKeys.all, "student-report-card", examId] as const,
 };

--- a/src/modules/exams/hooks/useExams.ts
+++ b/src/modules/exams/hooks/useExams.ts
@@ -14,6 +14,7 @@ import {
   fetchExamSchedules,
   fetchExams,
   fetchMyExamResults,
+  fetchMyExamSchedule,
   fetchMyReportCard,
   fetchReportCard,
   generateExamResults,
@@ -124,6 +125,13 @@ export function useMyExamResults() {
   return useQuery({
     queryKey: examQueryKeys.studentList(),
     queryFn: fetchMyExamResults,
+  });
+}
+
+export function useMyExamSchedule() {
+  return useQuery({
+    queryKey: examQueryKeys.studentSchedule(),
+    queryFn: fetchMyExamSchedule,
   });
 }
 

--- a/src/modules/exams/types/index.ts
+++ b/src/modules/exams/types/index.ts
@@ -190,3 +190,8 @@ export type UpsertMarkItem = {
   isAbsent?: boolean;
   remarks?: string | null;
 };
+
+export type StudentExamScheduleGroup = {
+  exam: Exam;
+  schedules: ExamSchedule[];
+};

--- a/src/modules/fees/api/fees.ts
+++ b/src/modules/fees/api/fees.ts
@@ -18,6 +18,7 @@ import type {
   StudentFeeDetail,
   StudentFeeStatus,
   StudentFeeSummary,
+  StudentFeesSummary,
   FineType,
   FeeFrequency,
 } from "@/modules/fees/types";
@@ -387,4 +388,9 @@ export async function downloadMyReceipt(paymentId: string): Promise<void> {
     responseType: "blob",
   });
   downloadBlob(res.data as Blob, `receipt-${paymentId}.pdf`);
+}
+
+export async function fetchMyFeesSummary(): Promise<StudentFeesSummary> {
+  const res = await API.get<StudentFeesSummary>(STUDENT_API.FEES_SUMMARY);
+  return res.data;
 }

--- a/src/modules/fees/constants/query-keys.ts
+++ b/src/modules/fees/constants/query-keys.ts
@@ -21,4 +21,5 @@ export const feeQueryKeys = {
     [...feeQueryKeys.all, "student", "fees", query ?? {}] as const,
   studentPayments: (query?: Record<string, unknown>) =>
     [...feeQueryKeys.all, "student", "payments", query ?? {}] as const,
+  studentSummary: () => [...feeQueryKeys.all, "student", "summary"] as const,
 };

--- a/src/modules/fees/hooks/useFees.ts
+++ b/src/modules/fees/hooks/useFees.ts
@@ -25,6 +25,7 @@ import {
   fetchMyFees,
   fetchStudentFeeDetail,
   fetchStudentFeeSummaries,
+  fetchMyFeesSummary,
   fetchStudentFees,
   optOutAssignment,
   previewFeeAssignment,
@@ -179,6 +180,13 @@ export function useMyFeePayments(query: Record<string, unknown> = {}) {
         page: (query.page as number) ?? 1,
         limit: (query.limit as number) ?? FEES_PAGE_SIZE,
       }),
+  });
+}
+
+export function useMyFeesSummary() {
+  return useQuery({
+    queryKey: feeQueryKeys.studentSummary(),
+    queryFn: fetchMyFeesSummary,
   });
 }
 

--- a/src/modules/fees/types/index.ts
+++ b/src/modules/fees/types/index.ts
@@ -265,3 +265,11 @@ export type PackageAssignItem = {
   optedIn: boolean;
   transportDistanceKm?: number;
 };
+
+export type StudentFeesSummary = {
+  totalOutstanding: number;
+  totalPaid: number;
+  overdueCount: number;
+  pendingCount: number;
+  totalAssignments: number;
+};

--- a/src/modules/parent-portal/api/parentPortal.ts
+++ b/src/modules/parent-portal/api/parentPortal.ts
@@ -1,0 +1,301 @@
+import { PARENT_API } from "@/config/api-routes";
+import API from "@/services/axios";
+import type {
+  ChildAnnouncementsPage,
+  ChildAttendanceRecord,
+  ChildClassInfo,
+  ChildDashboard,
+  ChildExamScheduleGroup,
+  ChildFeeSummary,
+  ChildMonthlyAttendance,
+  ChildProfile,
+  ChildProfileRaw,
+  ChildTimetableEntry,
+  FeePayment,
+  Homework,
+  HomeworkQuery,
+  Paginated,
+  ParentChild,
+  ParentMe,
+  ReportCard,
+  StudentFee,
+  StudentHomeworkDetail,
+} from "@/modules/parent-portal/types";
+import type { EntityDocument } from "@/modules/documents/types";
+import type { ExamResult } from "@/modules/exams/types";
+
+function asArray<T>(data: unknown): T[] {
+  if (Array.isArray(data)) return data as T[];
+  if (data && typeof data === "object" && Array.isArray((data as { data?: unknown }).data)) {
+    return (data as { data: T[] }).data;
+  }
+  return [];
+}
+
+function asPaginated<T>(data: unknown, page = 1, limit = 20): Paginated<T> {
+  if (data && typeof data === "object") {
+    const d = data as {
+      data?: T[];
+      items?: T[];
+      total?: number;
+      page?: number;
+      limit?: number;
+    };
+    const rows = Array.isArray(d.data)
+      ? d.data
+      : Array.isArray(d.items)
+        ? d.items
+        : [];
+    return {
+      data: rows,
+      total: typeof d.total === "number" ? d.total : rows.length,
+      page: typeof d.page === "number" ? d.page : page,
+      limit: typeof d.limit === "number" ? d.limit : limit,
+    };
+  }
+  return { data: [], total: 0, page, limit };
+}
+
+function formatDob(value: string | Date | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    const d = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(d.getTime())) return String(value);
+    return d.toLocaleDateString("en-IN");
+  } catch {
+    return String(value);
+  }
+}
+
+export function normalizeChildProfile(raw: ChildProfileRaw): ChildProfile {
+  const user = raw.user;
+  const profile = raw.profile;
+  const classInfo =
+    raw.class ??
+    (profile?.currentClass
+      ? {
+          id: profile.currentClass.id ?? "",
+          name: profile.currentClass.name ?? "",
+          section: profile.currentClass.section ?? null,
+        }
+      : null);
+
+  return {
+    id: raw.id ?? user?.id ?? "",
+    fullName: raw.fullName ?? user?.fullName ?? "Student",
+    studentCode: raw.studentCode ?? user?.studentCode ?? null,
+    dob: formatDob(raw.dob ?? user?.dateOfBirth),
+    gender: raw.gender ?? user?.gender ?? null,
+    bloodGroup: raw.bloodGroup ?? profile?.bloodGroup ?? null,
+    aadhaarNumber: raw.aadhaarNumber ?? profile?.aadhaarNumber ?? null,
+    phone: raw.phoneNumber ?? user?.mobile ?? null,
+    email: raw.email ?? user?.email ?? null,
+    address: raw.address ?? user?.address ?? null,
+    fatherName: raw.fatherName ?? profile?.fatherName ?? null,
+    fatherMobile: raw.fatherMobile ?? profile?.fatherMobile ?? null,
+    motherName: raw.motherName ?? profile?.motherName ?? null,
+    motherMobile: raw.motherMobile ?? profile?.motherMobile ?? null,
+    guardianName: raw.guardianName ?? profile?.guardianName ?? null,
+    guardianMobile: raw.guardianMobile ?? profile?.guardianMobile ?? null,
+    medicalNotes: profile?.medicalNotes ?? null,
+    class: classInfo && classInfo.id
+      ? {
+          id: classInfo.id,
+          name: classInfo.name ?? "",
+          section: classInfo.section ?? null,
+        }
+      : null,
+    documents: Array.isArray(raw.documents) ? raw.documents : [],
+  };
+}
+
+export async function fetchParentMe(): Promise<ParentMe> {
+  const res = await API.get<ParentMe>(PARENT_API.ME);
+  return res.data;
+}
+
+export async function fetchParentChildren(): Promise<ParentChild[]> {
+  const res = await API.get(PARENT_API.CHILDREN);
+  return asArray<ParentChild>(res.data);
+}
+
+export async function fetchChildDashboard(
+  studentId: string,
+): Promise<ChildDashboard> {
+  const res = await API.get<ChildDashboard>(
+    PARENT_API.CHILD_DASHBOARD(studentId),
+  );
+  return res.data ?? ({} as ChildDashboard);
+}
+
+export async function fetchChildProfile(
+  studentId: string,
+): Promise<ChildProfile> {
+  const res = await API.get<ChildProfileRaw>(
+    PARENT_API.CHILD_PROFILE(studentId),
+  );
+  return normalizeChildProfile(res.data ?? {});
+}
+
+export async function fetchChildAttendance(
+  studentId: string,
+  params?: { from?: string; to?: string },
+): Promise<ChildAttendanceRecord[]> {
+  const res = await API.get(PARENT_API.CHILD_ATTENDANCE(studentId), {
+    params,
+  });
+  return asArray<ChildAttendanceRecord>(res.data);
+}
+
+export async function fetchChildMonthlyAttendance(
+  studentId: string,
+  params?: { year?: number; month?: number },
+): Promise<ChildMonthlyAttendance> {
+  const res = await API.get<ChildMonthlyAttendance>(
+    PARENT_API.CHILD_ATTENDANCE_MONTHLY(studentId),
+    { params },
+  );
+  return (
+    res.data ?? {
+      studentId,
+      year: params?.year ?? new Date().getFullYear(),
+      month: params?.month ?? new Date().getMonth() + 1,
+      totalDays: 0,
+      present: 0,
+      absent: 0,
+      leave: 0,
+      percentage: 0,
+      details: [],
+    }
+  );
+}
+
+export async function fetchChildClass(
+  studentId: string,
+): Promise<ChildClassInfo> {
+  const res = await API.get<ChildClassInfo>(PARENT_API.CHILD_CLASS(studentId));
+  return res.data ?? null;
+}
+
+export async function fetchChildTimetable(
+  studentId: string,
+): Promise<ChildTimetableEntry[]> {
+  const res = await API.get(PARENT_API.CHILD_TIMETABLE(studentId));
+  return asArray<ChildTimetableEntry>(res.data);
+}
+
+export async function fetchChildAnnouncements(
+  studentId: string,
+  params?: { page?: number; limit?: number },
+): Promise<ChildAnnouncementsPage> {
+  const page = params?.page ?? 1;
+  const limit = params?.limit ?? 20;
+  const res = await API.get(PARENT_API.CHILD_ANNOUNCEMENTS(studentId), {
+    params: { page, limit },
+  });
+  const data = res.data ?? {};
+  if (data && typeof data === "object" && Array.isArray(data.items)) {
+    return {
+      items: data.items,
+      total: typeof data.total === "number" ? data.total : data.items.length,
+      page: typeof data.page === "number" ? data.page : page,
+      limit: typeof data.limit === "number" ? data.limit : limit,
+    };
+  }
+  const items = asArray<ChildAnnouncementsPage["items"][number]>(data);
+  return { items, total: items.length, page, limit };
+}
+
+export async function fetchChildDocuments(
+  studentId: string,
+): Promise<EntityDocument[]> {
+  const res = await API.get(PARENT_API.CHILD_DOCUMENTS(studentId));
+  return asArray<EntityDocument>(res.data);
+}
+
+export async function fetchChildHomework(
+  studentId: string,
+  query: HomeworkQuery = {},
+): Promise<Paginated<Homework>> {
+  const page = query.page ?? 1;
+  const limit = query.limit ?? 10;
+  const res = await API.get(PARENT_API.CHILD_HOMEWORK(studentId), {
+    params: query,
+  });
+  return asPaginated<Homework>(res.data, page, limit);
+}
+
+export async function fetchChildHomeworkDetail(
+  studentId: string,
+  homeworkId: string,
+): Promise<StudentHomeworkDetail> {
+  const res = await API.get<StudentHomeworkDetail>(
+    PARENT_API.CHILD_HOMEWORK_BY_ID(studentId, homeworkId),
+  );
+  return res.data;
+}
+
+export async function fetchChildFees(
+  studentId: string,
+  params?: { page?: number; limit?: number; status?: string },
+): Promise<Paginated<StudentFee>> {
+  const page = params?.page ?? 1;
+  const limit = params?.limit ?? 50;
+  const res = await API.get(PARENT_API.CHILD_FEES(studentId), {
+    params: { page, limit, status: params?.status },
+  });
+  return asPaginated<StudentFee>(res.data, page, limit);
+}
+
+export async function fetchChildFeesSummary(
+  studentId: string,
+): Promise<ChildFeeSummary> {
+  const res = await API.get<ChildFeeSummary>(
+    PARENT_API.CHILD_FEES_SUMMARY(studentId),
+  );
+  return (
+    res.data ?? {
+      totalOutstanding: 0,
+      totalPaid: 0,
+      overdueCount: 0,
+      pendingCount: 0,
+      totalAssignments: 0,
+    }
+  );
+}
+
+export async function fetchChildFeePayments(
+  studentId: string,
+  params?: { page?: number; limit?: number },
+): Promise<Paginated<FeePayment>> {
+  const page = params?.page ?? 1;
+  const limit = params?.limit ?? 50;
+  const res = await API.get(PARENT_API.CHILD_FEE_PAYMENTS(studentId), {
+    params: { page, limit },
+  });
+  return asPaginated<FeePayment>(res.data, page, limit);
+}
+
+export async function fetchChildExamResults(
+  studentId: string,
+): Promise<ExamResult[]> {
+  const res = await API.get(PARENT_API.CHILD_EXAMS(studentId));
+  return asArray<ExamResult>(res.data);
+}
+
+export async function fetchChildExamSchedule(
+  studentId: string,
+): Promise<ChildExamScheduleGroup[]> {
+  const res = await API.get(PARENT_API.CHILD_EXAMS_SCHEDULE(studentId));
+  return asArray<ChildExamScheduleGroup>(res.data);
+}
+
+export async function fetchChildReportCard(
+  studentId: string,
+  examId: string,
+): Promise<ReportCard> {
+  const res = await API.get<ReportCard>(
+    PARENT_API.CHILD_REPORT_CARD(studentId, examId),
+  );
+  return res.data;
+}

--- a/src/modules/parent-portal/components/ChildAnnouncementsView.tsx
+++ b/src/modules/parent-portal/components/ChildAnnouncementsView.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { useChildAnnouncementsQuery } from "@/modules/parent-portal/hooks/useParentPortal";
+import {
+  formatErrorMessage,
+  PortalEmpty,
+  PortalError,
+  PortalLoading,
+  PortalPageHeader,
+  PortalPageShell,
+} from "@/modules/parent-portal/components/PortalState";
+
+const PAGE_SIZE = 10;
+
+export default function ChildAnnouncementsView({
+  studentId,
+}: {
+  studentId: string;
+}) {
+  const [page, setPage] = useState(1);
+  const query = useChildAnnouncementsQuery(studentId, {
+    page,
+    limit: PAGE_SIZE,
+  });
+
+  if (query.isLoading && !query.data) return <PortalLoading rows={3} />;
+  if (query.error && !query.data) {
+    return (
+      <PortalError
+        message={formatErrorMessage(
+          query.error,
+          "Failed to load announcements",
+        )}
+        onRetry={() => void query.refetch()}
+      />
+    );
+  }
+
+  const items = query.data?.items ?? [];
+  const total = query.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <PortalPageShell>
+      <PortalPageHeader
+        title="Announcements"
+        description="School and class announcements for this student"
+      />
+
+      {items.length === 0 ? (
+        <PortalEmpty title="No announcements yet" />
+      ) : (
+        <div className="space-y-4">
+          {items.map((a) => (
+            <Card key={a.id} className="p-5">
+              <div className="flex flex-wrap items-center gap-2 text-sm text-slate-500">
+                {a.pinned ? (
+                  <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800">
+                    Pinned
+                  </span>
+                ) : null}
+                <span>
+                  {a.publishedAt
+                    ? new Date(a.publishedAt).toLocaleString("en-IN")
+                    : ""}
+                </span>
+                {a.authorName ? <span>· {a.authorName}</span> : null}
+              </div>
+              <h2 className="mt-3 text-xl font-semibold text-[#021034]">
+                {a.title}
+              </h2>
+              <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-[#737373]">
+                {a.body}
+              </p>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {totalPages > 1 ? (
+        <div className="mt-4 flex items-center justify-between text-sm text-slate-600">
+          <span>
+            Page {page} of {totalPages} · {total} total
+          </span>
+          <div className="flex gap-2">
+            <Button
+              variant="ghost"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="ghost"
+              disabled={page >= totalPages}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </PortalPageShell>
+  );
+}

--- a/src/modules/parent-portal/components/ChildAttendanceView.tsx
+++ b/src/modules/parent-portal/components/ChildAttendanceView.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Card from "@/components/ui/Card";
+import { AttendanceStatusBadge } from "@/modules/attendance";
+import { AttendanceSummary } from "@/modules/dashboard";
+import { DataTableSkeleton } from "@/components/skeletons";
+import {
+  useChildAttendanceQuery,
+  useChildMonthlyAttendanceQuery,
+} from "@/modules/parent-portal/hooks/useParentPortal";
+import {
+  formatErrorMessage,
+  PortalEmpty,
+  PortalError,
+  PortalLoading,
+  PortalPageHeader,
+  PortalPageShell,
+} from "@/modules/parent-portal/components/PortalState";
+
+export default function ChildAttendanceView({
+  studentId,
+}: {
+  studentId: string;
+}) {
+  const now = useMemo(() => new Date(), []);
+  const [year] = useState(now.getFullYear());
+  const [month] = useState(now.getMonth() + 1);
+
+  const monthlyQuery = useChildMonthlyAttendanceQuery(studentId, {
+    year,
+    month,
+  });
+  const historyQuery = useChildAttendanceQuery(studentId);
+
+  if (monthlyQuery.isLoading && historyQuery.isLoading) {
+    return <PortalLoading rows={3} />;
+  }
+
+  if (monthlyQuery.error && historyQuery.error) {
+    return (
+      <PortalError
+        message={formatErrorMessage(
+          monthlyQuery.error,
+          "Failed to load attendance",
+        )}
+        onRetry={() => {
+          void monthlyQuery.refetch();
+          void historyQuery.refetch();
+        }}
+      />
+    );
+  }
+
+  const monthly = monthlyQuery.data;
+  const history = historyQuery.data ?? [];
+
+  return (
+    <PortalPageShell>
+      <PortalPageHeader
+        title="Attendance"
+        description="Monthly summary and attendance history (read-only)"
+      />
+
+      <div className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="grid grid-cols-2 gap-3 lg:col-span-2 sm:grid-cols-4">
+          <Card>
+            <div className="text-sm text-slate-500">Present</div>
+            <div className="mt-2 text-2xl font-semibold text-[#021034]">
+              {monthly?.present ?? "—"}
+            </div>
+          </Card>
+          <Card>
+            <div className="text-sm text-slate-500">Absent</div>
+            <div className="mt-2 text-2xl font-semibold text-[#021034]">
+              {monthly?.absent ?? "—"}
+            </div>
+          </Card>
+          <Card>
+            <div className="text-sm text-slate-500">Leave</div>
+            <div className="mt-2 text-2xl font-semibold text-[#021034]">
+              {monthly?.leave ?? "—"}
+            </div>
+          </Card>
+          <Card>
+            <div className="text-sm text-slate-500">This month</div>
+            <div className="mt-2 text-2xl font-semibold text-[#021034]">
+              {monthly?.percentage ?? 0}%
+            </div>
+          </Card>
+        </div>
+        <AttendanceSummary
+          presentDays={monthly?.present ?? 0}
+          absentDays={monthly?.absent ?? 0}
+          monthlyPercentage={monthly?.percentage ?? 0}
+        />
+      </div>
+
+      <Card>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-[#021034]">
+            Attendance history
+          </h2>
+          <div className="text-sm text-slate-500">
+            {year}-{String(month).padStart(2, "0")} summary above
+          </div>
+        </div>
+
+        {historyQuery.isLoading ? (
+          <DataTableSkeleton
+            rows={8}
+            columns={[
+              { headerWidth: "w-24", cellWidth: "w-28" },
+              { headerWidth: "w-20", cellWidth: "w-20" },
+            ]}
+          />
+        ) : historyQuery.error ? (
+          <p className="text-sm text-slate-600">
+            {formatErrorMessage(historyQuery.error, "Failed to load history")}
+          </p>
+        ) : history.length === 0 ? (
+          <PortalEmpty title="No attendance records" />
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full table-auto">
+              <thead>
+                <tr className="text-left text-sm text-slate-600">
+                  <th className="py-2">Date</th>
+                  <th className="py-2">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {history.map((row, idx) => (
+                  <tr
+                    key={`${row.date}-${idx}`}
+                    className="border-t border-slate-100"
+                  >
+                    <td className="py-3 text-sm">
+                      {new Date(row.date).toLocaleDateString("en-IN")}
+                    </td>
+                    <td className="py-3">
+                      <AttendanceStatusBadge
+                        status={String(row.status || "").toUpperCase()}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </PortalPageShell>
+  );
+}

--- a/src/modules/parent-portal/components/ChildDashboardView.tsx
+++ b/src/modules/parent-portal/components/ChildDashboardView.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import Link from "next/link";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { AttendanceSummary } from "@/modules/dashboard";
+import {
+  useChildClassQuery,
+  useChildDashboardQuery,
+  useParentChildrenQuery,
+} from "@/modules/parent-portal/hooks/useParentPortal";
+import {
+  formatClassLabel,
+  formatErrorMessage,
+  PortalEmpty,
+  PortalError,
+  PortalLoading,
+  PortalPageHeader,
+  PortalPageShell,
+} from "@/modules/parent-portal/components/PortalState";
+
+const QUICK_LINKS = [
+  { label: "Attendance", path: "attendance" },
+  { label: "Timetable", path: "timetable" },
+  { label: "Homework", path: "homework" },
+  { label: "Fees", path: "fees" },
+  { label: "Exams", path: "exams" },
+  { label: "Announcements", path: "announcements" },
+] as const;
+
+export default function ChildDashboardView({
+  studentId,
+}: {
+  studentId: string;
+}) {
+  const childrenQuery = useParentChildrenQuery();
+  const dashboardQuery = useChildDashboardQuery(studentId);
+  const classQuery = useChildClassQuery(studentId);
+
+  const linked = (childrenQuery.data ?? []).some((c) => c.id === studentId);
+  const loading =
+    childrenQuery.isLoading ||
+    dashboardQuery.isLoading ||
+    classQuery.isLoading;
+  const error =
+    childrenQuery.error || dashboardQuery.error || classQuery.error;
+
+  if (loading) return <PortalLoading rows={4} />;
+
+  if (!childrenQuery.isLoading && !linked) {
+    return (
+      <PortalError
+        message="This student is not linked to your parent account."
+        onRetry={() => void childrenQuery.refetch()}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <PortalError
+        message={formatErrorMessage(error, "Failed to load child dashboard")}
+        onRetry={() => {
+          void dashboardQuery.refetch();
+          void classQuery.refetch();
+        }}
+      />
+    );
+  }
+
+  const data = dashboardQuery.data;
+  const childMeta = (childrenQuery.data ?? []).find((c) => c.id === studentId);
+  const classInfo = classQuery.data ?? data?.currentClass ?? null;
+  const presentDays = data?.presentDays ?? 0;
+  const absentDays = data?.absentDays ?? 0;
+  const percentage = data?.attendancePercentage ?? 0;
+  const timetable = data?.timetable ?? [];
+  const announcements = data?.recentAnnouncements ?? [];
+
+  return (
+    <PortalPageShell>
+      <PortalPageHeader
+        title={
+          data?.profile?.fullName ??
+          childMeta?.fullName ??
+          "Child dashboard"
+        }
+        description={`${formatClassLabel(
+          classInfo?.name ?? childMeta?.className,
+          classInfo?.section ?? childMeta?.section,
+        )}${
+          data?.profile?.studentCode || childMeta?.studentCode
+            ? ` · ${data?.profile?.studentCode ?? childMeta?.studentCode}`
+            : ""
+        }`}
+      />
+
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <Card>
+          <div className="text-sm text-slate-500">Attendance</div>
+          <div className="mt-2 text-2xl font-semibold text-[#021034]">
+            {percentage}%
+          </div>
+          <div className="mt-1 text-xs text-slate-500">
+            {presentDays} present · {absentDays} absent · {data?.leaveDays ?? 0}{" "}
+            leave
+          </div>
+        </Card>
+        <Card>
+          <div className="text-sm text-slate-500">Class</div>
+          <div className="mt-2 text-lg font-medium text-[#021034]">
+            {formatClassLabel(classInfo?.name, classInfo?.section)}
+          </div>
+        </Card>
+        <Card>
+          <div className="text-sm text-slate-500">Documents</div>
+          <div className="mt-2 text-2xl font-semibold text-[#021034]">
+            {data?.documents?.count ?? 0}
+          </div>
+          <Link
+            href={`/parent/children/${studentId}/documents`}
+            className="mt-2 inline-block text-sm text-blue-700 hover:underline"
+          >
+            View documents
+          </Link>
+        </Card>
+      </div>
+
+      <div className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div className="col-span-2 overflow-hidden rounded-xl border border-[#D7E3FC] bg-white">
+          <div className="border-b border-[#D7E3FC] px-6 py-4">
+            <h2 className="text-lg font-semibold text-[#021034]">
+              Class timetable (preview)
+            </h2>
+          </div>
+          {timetable.length === 0 ? (
+            <div className="px-6 py-10 text-center text-sm text-slate-500">
+              No timetable available.
+            </div>
+          ) : (
+            timetable.slice(0, 6).map((item, index) => (
+              <div
+                key={`${item.subject}-${item.startTime}-${index}`}
+                className="flex items-center justify-between border-b border-[#D7E3FC] px-6 py-4 last:border-b-0"
+              >
+                <div>
+                  <p className="font-medium text-[#021034]">
+                    {item.subject ?? "Class"}
+                  </p>
+                  <p className="mt-1 text-sm text-[#737373]">
+                    {item.startTime}
+                    {item.endTime ? `–${item.endTime}` : ""}
+                    {item.subjectTeacher
+                      ? ` · ${item.subjectTeacher}`
+                      : ""}
+                  </p>
+                </div>
+                <div className="rounded-full border border-[#D7E3FC] bg-blue-50 px-3 py-1 text-xs font-semibold text-[#021034]">
+                  {item.room ?? "—"}
+                </div>
+              </div>
+            ))
+          )}
+          <div className="border-t border-[#D7E3FC] px-6 py-3">
+            <Link href={`/parent/children/${studentId}/timetable`}>
+              <Button variant="ghost">Full timetable</Button>
+            </Link>
+          </div>
+        </div>
+
+        <AttendanceSummary
+          presentDays={presentDays}
+          absentDays={absentDays}
+          monthlyPercentage={percentage}
+        />
+      </div>
+
+      <div className="mb-6">
+        <h2 className="mb-3 text-lg font-semibold text-[#021034]">
+          Quick links
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {QUICK_LINKS.map((link) => (
+            <Link
+              key={link.path}
+              href={`/parent/children/${studentId}/${link.path}`}
+            >
+              <Button variant="ghost">{link.label}</Button>
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      <Card>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-[#021034]">
+            Recent announcements
+          </h2>
+          <Link href={`/parent/children/${studentId}/announcements`}>
+            <Button variant="ghost">View all</Button>
+          </Link>
+        </div>
+        {announcements.length === 0 ? (
+          <PortalEmpty title="No recent announcements" />
+        ) : (
+          <div className="divide-y divide-[#D7E3FC]">
+            {announcements.map((a) => (
+              <div key={a.id} className="py-3">
+                <div className="font-medium text-[#021034]">{a.title}</div>
+                <p className="mt-1 line-clamp-2 text-sm text-slate-600">
+                  {a.body}
+                </p>
+                <div className="mt-1 text-xs text-slate-500">
+                  {a.publishedAt
+                    ? new Date(a.publishedAt).toLocaleString("en-IN")
+                    : ""}
+                  {a.authorName ? ` · ${a.authorName}` : ""}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+    </PortalPageShell>
+  );
+}

--- a/src/modules/parent-portal/components/ChildDocumentsView.tsx
+++ b/src/modules/parent-portal/components/ChildDocumentsView.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import DocumentsGrid from "@/modules/documents/components/DocumentsGrid";
+import { DOCUMENT_TYPES } from "@/modules/documents/constants";
+import type { DocumentItem } from "@/modules/documents/types";
+import { useChildDocumentsQuery } from "@/modules/parent-portal/hooks/useParentPortal";
+import {
+  formatErrorMessage,
+  PortalEmpty,
+  PortalError,
+  PortalLoading,
+  PortalPageHeader,
+  PortalPageShell,
+} from "@/modules/parent-portal/components/PortalState";
+
+function labelForType(type: string): string {
+  const match = DOCUMENT_TYPES.find((d) => d.value === type);
+  return match?.label ?? type.replace(/_/g, " ");
+}
+
+export default function ChildDocumentsView({
+  studentId,
+}: {
+  studentId: string;
+}) {
+  const { data, isLoading, error, refetch } = useChildDocumentsQuery(studentId);
+
+  if (isLoading) return <PortalLoading rows={3} />;
+  if (error) {
+    return (
+      <PortalError
+        message={formatErrorMessage(error, "Failed to load documents")}
+        onRetry={() => void refetch()}
+      />
+    );
+  }
+
+  const docs = data ?? [];
+  const items: DocumentItem[] = docs.map((d) => ({
+    id: d.id,
+    title: d.originalName || d.fileName || labelForType(d.documentType),
+    type: labelForType(d.documentType),
+    href: d.url,
+  }));
+
+  return (
+    <PortalPageShell>
+      <PortalPageHeader
+        title="Documents"
+        description="Uploaded student documents (read-only)"
+      />
+
+      {items.length === 0 ? (
+        <PortalEmpty
+          title="No documents uploaded"
+          description="Documents uploaded by the school will appear here."
+        />
+      ) : (
+        <DocumentsGrid title="Student documents" documents={items} />
+      )}
+    </PortalPageShell>
+  );
+}

--- a/src/modules/parent-portal/components/ChildExamsView.tsx
+++ b/src/modules/parent-portal/components/ChildExamsView.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useState } from "react";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { DataTableSkeleton } from "@/components/skeletons";
+import { formatPercent } from "@/modules/exams";
+import {
+  useChildExamResultsQuery,
+  useChildExamScheduleQuery,
+  useChildReportCardQuery,
+} from "@/modules/parent-portal/hooks/useParentPortal";
+import {
+  formatErrorMessage,
+  PortalEmpty,
+  PortalError,
+  PortalLoading,
+  PortalPageHeader,
+  PortalPageShell,
+} from "@/modules/parent-portal/components/PortalState";
+
+export default function ChildExamsView({ studentId }: { studentId: string }) {
+  const [tab, setTab] = useState<"schedule" | "results">("schedule");
+  const [reportExamId, setReportExamId] = useState<string | null>(null);
+
+  const scheduleQuery = useChildExamScheduleQuery(studentId);
+  const resultsQuery = useChildExamResultsQuery(studentId);
+  const reportQuery = useChildReportCardQuery(
+    studentId,
+    reportExamId ?? undefined,
+  );
+
+  if (scheduleQuery.isLoading && resultsQuery.isLoading) {
+    return <PortalLoading rows={3} />;
+  }
+
+  if (scheduleQuery.error && resultsQuery.error) {
+    return (
+      <PortalError
+        message={formatErrorMessage(scheduleQuery.error, "Failed to load exams")}
+        onRetry={() => {
+          void scheduleQuery.refetch();
+          void resultsQuery.refetch();
+        }}
+      />
+    );
+  }
+
+  return (
+    <PortalPageShell>
+      <PortalPageHeader
+        title="Exams"
+        description="Schedule and published results (read-only)"
+      />
+
+      <div className="mb-4 flex gap-2">
+        <button
+          type="button"
+          className={`rounded-md px-3 py-1.5 text-sm font-medium ${
+            tab === "schedule"
+              ? "bg-[#DBEAFE] text-[#021034]"
+              : "border border-slate-200 bg-white text-slate-600"
+          }`}
+          onClick={() => {
+            setTab("schedule");
+            setReportExamId(null);
+          }}
+        >
+          Schedule
+        </button>
+        <button
+          type="button"
+          className={`rounded-md px-3 py-1.5 text-sm font-medium ${
+            tab === "results"
+              ? "bg-[#DBEAFE] text-[#021034]"
+              : "border border-slate-200 bg-white text-slate-600"
+          }`}
+          onClick={() => setTab("results")}
+        >
+          Results
+        </button>
+      </div>
+
+      {reportExamId ? (
+        <div className="mb-4">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <h2 className="text-lg font-semibold text-[#021034]">
+              Report card
+              {reportQuery.data?.exam.name
+                ? ` · ${reportQuery.data.exam.name}`
+                : ""}
+            </h2>
+            <Button variant="ghost" onClick={() => setReportExamId(null)}>
+              Back to results
+            </Button>
+          </div>
+          {reportQuery.isLoading ? (
+            <DataTableSkeleton
+              rows={6}
+              columns={[
+                { headerWidth: "w-32", cellWidth: "w-40" },
+                { headerWidth: "w-20", cellWidth: "w-24" },
+                { headerWidth: "w-16", cellWidth: "w-20" },
+              ]}
+            />
+          ) : reportQuery.error ? (
+            <Card>
+              <div className="flex flex-col gap-3">
+                <p className="text-sm text-slate-700">
+                  Failed to load report card. It may not be published yet.
+                </p>
+                <Button
+                  variant="dark"
+                  onClick={() => void reportQuery.refetch()}
+                >
+                  Retry
+                </Button>
+              </div>
+            </Card>
+          ) : (
+            <Card>
+              <div className="mb-4 border-b border-slate-100 pb-4">
+                <h3 className="text-lg font-semibold text-[#021034]">
+                  {reportQuery.data?.studentName}
+                </h3>
+                {reportQuery.data?.result ? (
+                  <p className="mt-2 text-sm">
+                    Overall: {reportQuery.data.result.totalObtainedMarks}/
+                    {reportQuery.data.result.totalMaxMarks} (
+                    {formatPercent(reportQuery.data.result.percentage)}) · Grade{" "}
+                    {reportQuery.data.result.grade ?? "—"} · Rank{" "}
+                    {reportQuery.data.result.rank ?? "—"}
+                  </p>
+                ) : null}
+              </div>
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-slate-500">
+                      <th className="py-2 pr-3">Subject</th>
+                      <th className="py-2 pr-3">Marks</th>
+                      <th className="py-2 pr-3">Grade</th>
+                      <th className="py-2">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {reportQuery.data!.subjects.map((s) => (
+                      <tr
+                        key={s.subjectId}
+                        className="border-t border-slate-100"
+                      >
+                        <td className="py-3 pr-3 font-medium text-[#021034]">
+                          {s.subjectName}
+                        </td>
+                        <td className="py-3 pr-3">
+                          {s.isAbsent
+                            ? "Absent"
+                            : `${s.marksObtained ?? "—"}/${s.maxMarks}`}
+                        </td>
+                        <td className="py-3 pr-3">{s.grade ?? "—"}</td>
+                        <td className="py-3">
+                          {s.isAbsent
+                            ? "Absent"
+                            : s.isPassed
+                              ? "Pass"
+                              : "Fail"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          )}
+        </div>
+      ) : tab === "schedule" ? (
+        scheduleQuery.isLoading ? (
+          <DataTableSkeleton
+            rows={5}
+            columns={[
+              { headerWidth: "w-40", cellWidth: "w-48" },
+              { headerWidth: "w-28", cellWidth: "w-32" },
+            ]}
+          />
+        ) : scheduleQuery.error ? (
+          <Card>
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-slate-700">Failed to load schedule.</p>
+              <Button
+                variant="dark"
+                onClick={() => void scheduleQuery.refetch()}
+              >
+                Retry
+              </Button>
+            </div>
+          </Card>
+        ) : (scheduleQuery.data ?? []).length === 0 ? (
+          <PortalEmpty title="No exam schedule available" />
+        ) : (
+          <div className="space-y-4">
+            {(scheduleQuery.data ?? []).map((group) => (
+              <Card key={group.exam.id}>
+                <div className="mb-3">
+                  <h3 className="text-base font-semibold text-[#021034]">
+                    {group.exam.name}
+                  </h3>
+                  <p className="text-sm text-slate-500">
+                    {group.exam.academicYear}
+                    {group.exam.className ? ` · ${group.exam.className}` : ""}
+                    {group.exam.status ? ` · ${group.exam.status}` : ""}
+                  </p>
+                </div>
+                {(group.schedules ?? []).length === 0 ? (
+                  <p className="text-sm text-slate-500">No subjects scheduled.</p>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full text-sm">
+                      <thead>
+                        <tr className="text-left text-slate-500">
+                          <th className="py-2 pr-3">Subject</th>
+                          <th className="py-2 pr-3">Date</th>
+                          <th className="py-2 pr-3">Time</th>
+                          <th className="py-2">Venue</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {group.schedules.map((s) => (
+                          <tr key={s.id} className="border-t border-slate-100">
+                            <td className="py-3 pr-3 font-medium text-[#021034]">
+                              {s.subjectName ?? "—"}
+                            </td>
+                            <td className="py-3 pr-3">
+                              {s.examDate
+                                ? new Date(s.examDate).toLocaleDateString(
+                                    "en-IN",
+                                  )
+                                : "—"}
+                            </td>
+                            <td className="py-3 pr-3">
+                              {s.startTime ?? "—"}
+                              {s.endTime ? `–${s.endTime}` : ""}
+                            </td>
+                            <td className="py-3">{s.venue ?? "—"}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </Card>
+            ))}
+          </div>
+        )
+      ) : resultsQuery.isLoading ? (
+        <DataTableSkeleton
+          rows={6}
+          columns={[
+            { headerWidth: "w-40", cellWidth: "w-48" },
+            { headerWidth: "w-24", cellWidth: "w-28" },
+            { headerWidth: "w-20", cellWidth: "w-24" },
+          ]}
+        />
+      ) : resultsQuery.error ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-slate-700">Failed to load results.</p>
+            <Button variant="dark" onClick={() => void resultsQuery.refetch()}>
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-slate-500">
+                  <th className="py-2 pr-3">Exam</th>
+                  <th className="hidden py-2 pr-3 md:table-cell">Class</th>
+                  <th className="py-2 pr-3">%</th>
+                  <th className="py-2 pr-3">Grade</th>
+                  <th className="py-2">Report card</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(resultsQuery.data ?? []).length === 0 ? (
+                  <tr>
+                    <td colSpan={5} className="py-8 text-center text-slate-500">
+                      No published results yet.
+                    </td>
+                  </tr>
+                ) : (
+                  resultsQuery.data!.map((r) => (
+                    <tr key={r.id} className="border-t border-slate-100">
+                      <td className="py-3 pr-3 font-medium text-[#021034]">
+                        {r.examName}
+                      </td>
+                      <td className="hidden py-3 pr-3 md:table-cell">
+                        {r.className ?? "—"}
+                      </td>
+                      <td className="py-3 pr-3">
+                        {formatPercent(r.percentage)}
+                      </td>
+                      <td className="py-3 pr-3">{r.grade ?? "—"}</td>
+                      <td className="py-3">
+                        <Button
+                          variant="ghost"
+                          onClick={() => setReportExamId(r.examId)}
+                        >
+                          View
+                        </Button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+    </PortalPageShell>
+  );
+}

--- a/src/modules/parent-portal/components/ChildFeesView.tsx
+++ b/src/modules/parent-portal/components/ChildFeesView.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useState } from "react";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { DataTableSkeleton } from "@/components/skeletons";
+import {
+  FEE_STATUS_LABELS,
+  PAYMENT_METHOD_LABELS,
+  formatInr,
+} from "@/modules/fees";
+import {
+  useChildFeePaymentsQuery,
+  useChildFeesQuery,
+  useChildFeesSummaryQuery,
+} from "@/modules/parent-portal/hooks/useParentPortal";
+import {
+  formatErrorMessage,
+  PortalError,
+  PortalLoading,
+  PortalPageHeader,
+  PortalPageShell,
+} from "@/modules/parent-portal/components/PortalState";
+
+export default function ChildFeesView({ studentId }: { studentId: string }) {
+  const [tab, setTab] = useState<"dues" | "history">("dues");
+  const summaryQuery = useChildFeesSummaryQuery(studentId);
+  const feesQuery = useChildFeesQuery(studentId, { page: 1, limit: 50 });
+  const paymentsQuery = useChildFeePaymentsQuery(studentId, {
+    page: 1,
+    limit: 50,
+  });
+
+  if (summaryQuery.isLoading && feesQuery.isLoading) {
+    return <PortalLoading rows={3} />;
+  }
+
+  if (summaryQuery.error && feesQuery.error) {
+    return (
+      <PortalError
+        message={formatErrorMessage(summaryQuery.error, "Failed to load fees")}
+        onRetry={() => {
+          void summaryQuery.refetch();
+          void feesQuery.refetch();
+        }}
+      />
+    );
+  }
+
+  const summary = summaryQuery.data;
+
+  return (
+    <PortalPageShell>
+      <PortalPageHeader
+        title="Fees"
+        description="Outstanding dues and payment history (read-only)"
+      />
+
+      <p className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+        Fees are view-only. Contact the school office to make payments.
+      </p>
+
+      <div className="mb-6 grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <Card>
+          <div className="text-sm text-slate-500">Outstanding</div>
+          <div className="mt-2 text-xl font-semibold text-[#021034]">
+            {formatInr(summary?.totalOutstanding)}
+          </div>
+        </Card>
+        <Card>
+          <div className="text-sm text-slate-500">Paid</div>
+          <div className="mt-2 text-xl font-semibold text-[#021034]">
+            {formatInr(summary?.totalPaid)}
+          </div>
+        </Card>
+        <Card>
+          <div className="text-sm text-slate-500">Pending</div>
+          <div className="mt-2 text-xl font-semibold text-[#021034]">
+            {summary?.pendingCount ?? 0}
+          </div>
+        </Card>
+        <Card>
+          <div className="text-sm text-slate-500">Overdue</div>
+          <div className="mt-2 text-xl font-semibold text-[#021034]">
+            {summary?.overdueCount ?? 0}
+          </div>
+        </Card>
+      </div>
+
+      <div className="mb-4 flex gap-2">
+        <button
+          type="button"
+          className={`rounded-md px-3 py-1.5 text-sm font-medium ${
+            tab === "dues"
+              ? "bg-[#DBEAFE] text-[#021034]"
+              : "border border-slate-200 bg-white text-slate-600"
+          }`}
+          onClick={() => setTab("dues")}
+        >
+          Dues
+        </button>
+        <button
+          type="button"
+          className={`rounded-md px-3 py-1.5 text-sm font-medium ${
+            tab === "history"
+              ? "bg-[#DBEAFE] text-[#021034]"
+              : "border border-slate-200 bg-white text-slate-600"
+          }`}
+          onClick={() => setTab("history")}
+        >
+          Payment history
+        </button>
+      </div>
+
+      {tab === "dues" ? (
+        feesQuery.isLoading ? (
+          <DataTableSkeleton
+            rows={5}
+            columns={[
+              { headerWidth: "w-32", cellWidth: "w-40" },
+              { headerWidth: "w-24", cellWidth: "w-28" },
+              { headerWidth: "w-20", cellWidth: "w-24" },
+            ]}
+          />
+        ) : feesQuery.error ? (
+          <Card>
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-slate-700">Failed to load fees.</p>
+              <Button variant="dark" onClick={() => void feesQuery.refetch()}>
+                Retry
+              </Button>
+            </div>
+          </Card>
+        ) : (
+          <Card>
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="text-left text-slate-500">
+                    <th className="py-2 pr-3">Fee</th>
+                    <th className="py-2 pr-3">Outstanding</th>
+                    <th className="py-2 pr-3">Due date</th>
+                    <th className="py-2">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(feesQuery.data?.data ?? []).length === 0 ? (
+                    <tr>
+                      <td colSpan={4} className="py-6 text-slate-500">
+                        No fee assignments
+                      </td>
+                    </tr>
+                  ) : (
+                    feesQuery.data!.data.map((row) => (
+                      <tr key={row.id} className="border-t">
+                        <td className="py-3 pr-3">
+                          <div className="font-medium text-[#021034]">
+                            {row.feeStructureName ?? "—"}
+                          </div>
+                          <div className="text-xs text-slate-500">
+                            {row.categoryName ?? ""}
+                          </div>
+                        </td>
+                        <td className="py-3 pr-3">
+                          {formatInr(row.outstandingAmount)}
+                          <div className="text-xs text-slate-500">
+                            Paid {formatInr(row.paidAmount)} · Fine{" "}
+                            {formatInr(row.fineAmount)}
+                          </div>
+                        </td>
+                        <td className="py-3 pr-3">
+                          {row.dueDate?.slice(0, 10)}
+                        </td>
+                        <td className="py-3">
+                          {FEE_STATUS_LABELS[row.status] ?? row.status}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </Card>
+        )
+      ) : paymentsQuery.isLoading ? (
+        <DataTableSkeleton
+          rows={5}
+          columns={[
+            { headerWidth: "w-28", cellWidth: "w-32" },
+            { headerWidth: "w-24", cellWidth: "w-28" },
+            { headerWidth: "w-20", cellWidth: "w-24" },
+          ]}
+        />
+      ) : paymentsQuery.error ? (
+        <Card>
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-slate-700">Failed to load payments.</p>
+            <Button
+              variant="dark"
+              onClick={() => void paymentsQuery.refetch()}
+            >
+              Retry
+            </Button>
+          </div>
+        </Card>
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-slate-500">
+                  <th className="py-2 pr-3">Receipt</th>
+                  <th className="py-2 pr-3">Amount</th>
+                  <th className="py-2 pr-3">Method</th>
+                  <th className="py-2">Paid at</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(paymentsQuery.data?.data ?? []).length === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="py-6 text-slate-500">
+                      No payments yet
+                    </td>
+                  </tr>
+                ) : (
+                  paymentsQuery.data!.data.map((row) => (
+                    <tr key={row.id} className="border-t">
+                      <td className="py-3 pr-3">{row.receiptNumber}</td>
+                      <td className="py-3 pr-3">{formatInr(row.amount)}</td>
+                      <td className="py-3 pr-3">
+                        {PAYMENT_METHOD_LABELS[row.method] ?? row.method}
+                      </td>
+                      <td className="py-3">
+                        {new Date(row.paidAt).toLocaleString("en-IN")}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+    </PortalPageShell>
+  );
+}

--- a/src/modules/parent-portal/components/ChildFeesView.tsx
+++ b/src/modules/parent-portal/components/ChildFeesView.tsx
@@ -169,7 +169,7 @@ export default function ChildFeesView({ studentId }: { studentId: string }) {
                           </div>
                         </td>
                         <td className="py-3 pr-3">
-                          {row.dueDate?.slice(0, 10)}
+                          —
                         </td>
                         <td className="py-3">
                           {FEE_STATUS_LABELS[row.status] ?? row.status}

--- a/src/modules/parent-portal/components/ChildHomeworkDetailView.tsx
+++ b/src/modules/parent-portal/components/ChildHomeworkDetailView.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import Link from "next/link";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import {
+  HOMEWORK_TYPE_LABELS,
+  HomeworkStatusBadge,
+  SubmissionStatusBadge,
+  formatDueAt,
+} from "@/modules/homework";
+import { useChildHomeworkDetailQuery } from "@/modules/parent-portal/hooks/useParentPortal";
+import {
+  formatErrorMessage,
+  PortalError,
+  PortalLoading,
+  PortalPageHeader,
+  PortalPageShell,
+} from "@/modules/parent-portal/components/PortalState";
+
+export default function ChildHomeworkDetailView({
+  studentId,
+  homeworkId,
+}: {
+  studentId: string;
+  homeworkId: string;
+}) {
+  const { data, isLoading, error, refetch } = useChildHomeworkDetailQuery(
+    studentId,
+    homeworkId,
+  );
+
+  if (isLoading) return <PortalLoading rows={3} />;
+  if (error || !data) {
+    return (
+      <PortalError
+        message={formatErrorMessage(error, "Homework not found")}
+        onRetry={() => void refetch()}
+      />
+    );
+  }
+
+  return (
+    <PortalPageShell>
+      <PortalPageHeader
+        title={data.title}
+        description={`${HOMEWORK_TYPE_LABELS[data.type]} · Due ${formatDueAt(data.dueAt)}`}
+        actions={
+          <Link href={`/parent/children/${studentId}/homework`}>
+            <Button variant="ghost">Back to list</Button>
+          </Link>
+        }
+      />
+
+      <p className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+        Read-only view. Parents cannot submit homework on behalf of students.
+      </p>
+
+      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+        <Card className="p-5">
+          <div className="mb-3 flex flex-wrap items-center gap-2">
+            <HomeworkStatusBadge status={data.status} />
+            {data.mySubmissionStatus ? (
+              <SubmissionStatusBadge status={data.mySubmissionStatus} />
+            ) : null}
+          </div>
+          <h2 className="mb-2 text-sm font-semibold text-[#021034]">
+            Instructions
+          </h2>
+          <p className="whitespace-pre-wrap text-sm text-slate-700">
+            {data.description || "No description provided."}
+          </p>
+          {data.attachments?.length ? (
+            <div className="mt-4">
+              <h3 className="mb-2 text-sm font-semibold text-[#021034]">
+                Attachments
+              </h3>
+              <ul className="space-y-1 text-sm">
+                {data.attachments.map((a, i) => (
+                  <li key={`${a.url}-${i}`}>
+                    <a
+                      href={a.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-blue-700 hover:underline"
+                    >
+                      {a.filename}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </Card>
+
+        <Card className="space-y-3 p-5 text-sm">
+          <div>
+            <div className="text-slate-500">Subject</div>
+            <div className="font-medium text-[#021034]">
+              {data.subjectName || "—"}
+            </div>
+          </div>
+          <div>
+            <div className="text-slate-500">Max marks</div>
+            <div className="font-medium text-[#021034]">
+              {data.maxMarks ?? "—"}
+            </div>
+          </div>
+          <div>
+            <div className="text-slate-500">Late submissions</div>
+            <div className="font-medium text-[#021034]">
+              {data.allowLateSubmission ? "Allowed" : "Not allowed"}
+            </div>
+          </div>
+        </Card>
+      </div>
+
+      <Card className="mt-4 p-5">
+        <h2 className="mb-3 text-sm font-semibold text-[#021034]">
+          Student submission
+        </h2>
+        {!data.mySubmission ? (
+          <p className="text-sm text-slate-600">Not submitted yet.</p>
+        ) : (
+          <div className="space-y-2 text-sm">
+            <div className="flex flex-wrap items-center gap-2">
+              <SubmissionStatusBadge status={data.mySubmission.status} />
+              {data.mySubmission.isLate ? (
+                <span className="text-xs text-orange-600">Late</span>
+              ) : null}
+              {data.mySubmission.submittedAt ? (
+                <span className="text-slate-500">
+                  {formatDueAt(data.mySubmission.submittedAt)}
+                </span>
+              ) : null}
+            </div>
+            <p className="whitespace-pre-wrap text-slate-700">
+              {data.mySubmission.content || "No text content."}
+            </p>
+            {data.mySubmission.attachments?.length ? (
+              <ul className="space-y-1">
+                {data.mySubmission.attachments.map((a, i) => (
+                  <li key={`${a.url}-${i}`}>
+                    <a
+                      href={a.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-blue-700 hover:underline"
+                    >
+                      {a.filename}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {(data.mySubmission.marksObtained != null ||
+              data.mySubmission.remarks) && (
+              <div className="rounded-md border border-[#E8EEF9] bg-[#F8FBFF] p-3">
+                <div>
+                  Marks:{" "}
+                  <span className="font-medium">
+                    {data.mySubmission.marksObtained ?? "—"}
+                  </span>
+                </div>
+                {data.mySubmission.remarks ? (
+                  <div className="mt-1 text-slate-700">
+                    Remarks: {data.mySubmission.remarks}
+                  </div>
+                ) : null}
+              </div>
+            )}
+          </div>
+        )}
+      </Card>
+    </PortalPageShell>
+  );
+}

--- a/src/modules/parent-portal/components/ChildHomeworkListView.tsx
+++ b/src/modules/parent-portal/components/ChildHomeworkListView.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import {
+  HOMEWORK_TYPE_LABELS,
+  HomeworkStatusBadge,
+  SubmissionStatusBadge,
+  formatDueAt,
+  isOverdue,
+  type HomeworkStatus,
+  type HomeworkType,
+} from "@/modules/homework";
+import { PARENT_PORTAL_PAGE_SIZE } from "@/modules/parent-portal/constants/query-keys";
+import { useChildHomeworkQuery } from "@/modules/parent-portal/hooks/useParentPortal";
+import {
+  formatErrorMessage,
+  PortalEmpty,
+  PortalError,
+  PortalLoading,
+  PortalPageHeader,
+  PortalPageShell,
+} from "@/modules/parent-portal/components/PortalState";
+
+export default function ChildHomeworkListView({
+  studentId,
+}: {
+  studentId: string;
+}) {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [type, setType] = useState<HomeworkType | "">("");
+  const [status, setStatus] = useState<HomeworkStatus | "">("");
+
+  const listQuery = useChildHomeworkQuery(studentId, {
+    page,
+    limit: PARENT_PORTAL_PAGE_SIZE,
+    search: search.trim() || undefined,
+    type: type || undefined,
+    status: status || undefined,
+  });
+
+  const rows = listQuery.data?.data ?? [];
+  const total = listQuery.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PARENT_PORTAL_PAGE_SIZE));
+
+  if (listQuery.isLoading && rows.length === 0) {
+    return <PortalLoading rows={3} />;
+  }
+
+  if (listQuery.error && rows.length === 0) {
+    return (
+      <PortalError
+        message={formatErrorMessage(listQuery.error, "Failed to load homework")}
+        onRetry={() => void listQuery.refetch()}
+      />
+    );
+  }
+
+  return (
+    <PortalPageShell>
+      <PortalPageHeader
+        title="Homework"
+        description="Assigned work and submission status (read-only)"
+      />
+
+      <div className="mb-4 flex flex-wrap gap-2">
+        <Input
+          className="max-w-xs"
+          placeholder="Search…"
+          value={search}
+          onChange={(e) => {
+            setPage(1);
+            setSearch(e.target.value);
+          }}
+        />
+        <select
+          className="rounded-md border border-[#D7E3FC] px-3 py-2 text-sm"
+          value={type}
+          onChange={(e) => {
+            setPage(1);
+            setType(e.target.value as HomeworkType | "");
+          }}
+        >
+          <option value="">All types</option>
+          <option value="HOMEWORK">Homework</option>
+          <option value="ASSIGNMENT">Assignment</option>
+        </select>
+        <select
+          className="rounded-md border border-[#D7E3FC] px-3 py-2 text-sm"
+          value={status}
+          onChange={(e) => {
+            setPage(1);
+            setStatus(e.target.value as HomeworkStatus | "");
+          }}
+        >
+          <option value="">Open & closed</option>
+          <option value="PUBLISHED">Published</option>
+          <option value="CLOSED">Closed</option>
+        </select>
+      </div>
+
+      <div className="grid gap-3">
+        {listQuery.isLoading ? (
+          <Card className="p-5 text-sm text-slate-600">Loading…</Card>
+        ) : rows.length === 0 ? (
+          <PortalEmpty title="No homework assigned yet." />
+        ) : (
+          rows.map((row) => (
+            <Card key={row.id} className="p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Link
+                      href={`/parent/children/${studentId}/homework/${row.id}`}
+                      className="text-base font-semibold text-[#021034] hover:underline"
+                    >
+                      {row.title}
+                    </Link>
+                    <HomeworkStatusBadge status={row.status} />
+                    {row.mySubmissionStatus ? (
+                      <SubmissionStatusBadge status={row.mySubmissionStatus} />
+                    ) : null}
+                  </div>
+                  <p className="mt-1 text-sm text-slate-600">
+                    {HOMEWORK_TYPE_LABELS[row.type]}
+                    {row.subjectName ? ` · ${row.subjectName}` : ""}
+                    {" · Due "}
+                    {formatDueAt(row.dueAt)}
+                    {isOverdue(row.dueAt, row.status) ? (
+                      <span className="text-orange-600"> · Overdue</span>
+                    ) : null}
+                  </p>
+                </div>
+                <Link
+                  href={`/parent/children/${studentId}/homework/${row.id}`}
+                >
+                  <Button variant="dark">View</Button>
+                </Link>
+              </div>
+            </Card>
+          ))
+        )}
+      </div>
+
+      <div className="mt-4 flex items-center justify-between text-sm text-slate-600">
+        <span>
+          Page {page} of {totalPages} · {total} total
+        </span>
+        <div className="flex gap-2">
+          <Button
+            variant="ghost"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="ghost"
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+    </PortalPageShell>
+  );
+}

--- a/src/modules/parent-portal/components/ChildProfileView.tsx
+++ b/src/modules/parent-portal/components/ChildProfileView.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import Card from "@/components/ui/Card";
+import InfoField from "@/components/profile/InfoField";
+import { useChildProfileQuery } from "@/modules/parent-portal/hooks/useParentPortal";
+import {
+  formatClassLabel,
+  formatErrorMessage,
+  PortalError,
+  PortalLoading,
+  PortalPageHeader,
+  PortalPageShell,
+} from "@/modules/parent-portal/components/PortalState";
+
+export default function ChildProfileView({
+  studentId,
+}: {
+  studentId: string;
+}) {
+  const { data, isLoading, error, refetch } = useChildProfileQuery(studentId);
+
+  if (isLoading) return <PortalLoading rows={4} />;
+  if (error || !data) {
+    return (
+      <PortalError
+        message={formatErrorMessage(error, "Failed to load profile")}
+        onRetry={() => void refetch()}
+      />
+    );
+  }
+
+  return (
+    <PortalPageShell>
+      <PortalPageHeader
+        title={data.fullName}
+        description="Read-only student profile"
+      />
+
+      <Card className="mb-5">
+        <div className="text-[20px] font-[600] text-[#021034]">
+          {data.fullName}
+        </div>
+        <div className="mt-1 text-sm text-[#737373]">
+          Student ID: {data.studentCode ?? data.id}
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <span className="rounded-full border border-[#D7E3FC] bg-[#F5F9FF] px-2 py-1 text-xs font-semibold text-[#021034]">
+            {formatClassLabel(data.class?.name, data.class?.section)}
+          </span>
+        </div>
+      </Card>
+
+      <div className="mb-5 grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <div className="rounded-xl border border-blue-200 bg-white p-4">
+          <h2 className="mb-5 text-[16px] font-semibold text-gray-900 lg:text-[20px]">
+            Personal Information
+          </h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <InfoField label="Full Name" value={data.fullName} />
+            <InfoField label="Date of Birth" value={data.dob ?? "—"} />
+            <InfoField label="Gender" value={data.gender ?? "—"} />
+            <InfoField label="Blood Group" value={data.bloodGroup ?? "—"} />
+            <InfoField
+              label="Aadhaar Number"
+              value={data.aadhaarNumber ?? "—"}
+            />
+            <InfoField label="Phone No." value={data.phone ?? "—"} />
+            <InfoField label="Email Address" value={data.email ?? "—"} />
+            <div className="sm:col-span-2">
+              <InfoField label="Address" value={data.address ?? "—"} />
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-blue-200 bg-white p-4">
+          <h2 className="mb-5 text-[16px] font-semibold text-gray-900 lg:text-[20px]">
+            Parent / Guardian Information
+          </h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <InfoField label="Father Name" value={data.fatherName ?? "—"} />
+            <InfoField
+              label="Father Contact"
+              value={data.fatherMobile ?? "—"}
+            />
+            <InfoField label="Mother Name" value={data.motherName ?? "—"} />
+            <InfoField
+              label="Mother Contact"
+              value={data.motherMobile ?? "—"}
+            />
+            <InfoField
+              label="Guardian Name"
+              value={data.guardianName ?? "—"}
+            />
+            <InfoField
+              label="Guardian Contact"
+              value={data.guardianMobile ?? "—"}
+            />
+            {data.medicalNotes ? (
+              <div className="sm:col-span-2">
+                <InfoField label="Medical Notes" value={data.medicalNotes} />
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <p className="text-center text-sm font-medium text-[#737373]">
+        This profile is read-only. Contact the school office for corrections.
+      </p>
+    </PortalPageShell>
+  );
+}

--- a/src/modules/parent-portal/components/ChildSubnav.tsx
+++ b/src/modules/parent-portal/components/ChildSubnav.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const LINKS = [
+  { label: "Overview", href: "" },
+  { label: "Profile", href: "/profile" },
+  { label: "Attendance", href: "/attendance" },
+  { label: "Timetable", href: "/timetable" },
+  { label: "Homework", href: "/homework" },
+  { label: "Fees", href: "/fees" },
+  { label: "Exams", href: "/exams" },
+  { label: "Announcements", href: "/announcements" },
+  { label: "Documents", href: "/documents" },
+] as const;
+
+export default function ChildSubnav({ studentId }: { studentId: string }) {
+  const pathname = usePathname();
+  const base = `/parent/children/${studentId}`;
+
+  return (
+    <nav className="mb-6 flex flex-wrap gap-2 border-b border-[#D7E3FC] pb-3">
+      {LINKS.map((link) => {
+        const href = `${base}${link.href}`;
+        const isOverview = link.href === "";
+        const active = isOverview
+          ? pathname === base || pathname === `${base}/`
+          : pathname === href || pathname.startsWith(`${href}/`);
+
+        return (
+          <Link
+            key={link.label}
+            href={href}
+            className={`rounded-md px-3 py-1.5 text-sm font-medium transition ${
+              active
+                ? "bg-[#DBEAFE] text-[#021034]"
+                : "border border-transparent text-slate-600 hover:bg-slate-50"
+            }`}
+          >
+            {link.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/modules/parent-portal/components/ChildSwitcher.tsx
+++ b/src/modules/parent-portal/components/ChildSwitcher.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useParentChildrenQuery } from "@/modules/parent-portal/hooks/useParentPortal";
+import {
+  formatClassLabel,
+  RELATIONSHIP_LABELS,
+} from "@/modules/parent-portal/components/PortalState";
+
+const CHILD_SECTIONS = [
+  "profile",
+  "attendance",
+  "timetable",
+  "homework",
+  "fees",
+  "exams",
+  "announcements",
+  "documents",
+] as const;
+
+function pathForChild(pathname: string, fromId: string, toId: string): string {
+  const base = `/parent/children/${fromId}`;
+  if (!pathname.startsWith(base)) {
+    return `/parent/children/${toId}`;
+  }
+  const rest = pathname.slice(base.length);
+  const segment = rest.split("/").filter(Boolean)[0];
+  if (segment && (CHILD_SECTIONS as readonly string[]).includes(segment)) {
+    return `/parent/children/${toId}/${segment}`;
+  }
+  return `/parent/children/${toId}`;
+}
+
+export default function ChildSwitcher({
+  studentId,
+}: {
+  studentId: string;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { data: children = [], isLoading } = useParentChildrenQuery();
+
+  if (isLoading) {
+    return (
+      <div className="h-10 w-full max-w-sm animate-pulse rounded-md bg-slate-100" />
+    );
+  }
+
+  if (children.length === 0) {
+    return (
+      <p className="text-sm text-slate-600">
+        No children linked.{" "}
+        <Link href="/parent/children" className="text-blue-700 hover:underline">
+          View children
+        </Link>
+      </p>
+    );
+  }
+
+  const current = children.find((c) => c.id === studentId);
+
+  return (
+    <div className="flex flex-wrap items-end gap-3">
+      <label className="flex min-w-[220px] flex-1 flex-col gap-1 text-sm">
+        <span className="font-medium text-slate-600">Viewing child</span>
+        <select
+          className="rounded-md border border-[#D7E3FC] bg-white px-3 py-2 text-sm text-[#021034]"
+          value={studentId}
+          onChange={(e) => {
+            const nextId = e.target.value;
+            if (!nextId || nextId === studentId) return;
+            router.push(pathForChild(pathname, studentId, nextId));
+          }}
+        >
+          {children.map((child) => (
+            <option key={child.id} value={child.id}>
+              {child.fullName}
+              {child.studentCode ? ` (${child.studentCode})` : ""}
+            </option>
+          ))}
+        </select>
+      </label>
+      {current ? (
+        <div className="pb-2 text-sm text-slate-500">
+          {formatClassLabel(current.className, current.section)}
+          {" · "}
+          {RELATIONSHIP_LABELS[current.relationship] ?? current.relationship}
+        </div>
+      ) : (
+        <div className="pb-2 text-sm text-amber-700">
+          This student is not linked to your account.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/modules/parent-portal/components/ChildTimetableView.tsx
+++ b/src/modules/parent-portal/components/ChildTimetableView.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import Card from "@/components/ui/Card";
+import { useChildTimetableQuery } from "@/modules/parent-portal/hooks/useParentPortal";
+import {
+  formatErrorMessage,
+  PortalEmpty,
+  PortalError,
+  PortalLoading,
+  PortalPageHeader,
+  PortalPageShell,
+} from "@/modules/parent-portal/components/PortalState";
+
+export default function ChildTimetableView({
+  studentId,
+}: {
+  studentId: string;
+}) {
+  const { data, isLoading, error, refetch } = useChildTimetableQuery(studentId);
+  const entries = data ?? [];
+
+  if (isLoading) return <PortalLoading rows={4} />;
+  if (error) {
+    return (
+      <PortalError
+        message={formatErrorMessage(error, "Failed to load timetable")}
+        onRetry={() => void refetch()}
+      />
+    );
+  }
+
+  return (
+    <PortalPageShell>
+      <PortalPageHeader
+        title="Timetable"
+        description="Class schedule for this student"
+      />
+
+      {entries.length === 0 ? (
+        <PortalEmpty
+          title="No timetable available"
+          description="The class may not have a timetable set yet."
+        />
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-[#D7E3FC] bg-white">
+          {entries.map((item, index) => (
+            <div
+              key={`${item.subject}-${item.startTime}-${index}`}
+              className="flex items-center justify-between border-b border-[#D7E3FC] px-6 py-4 last:border-b-0"
+            >
+              <div className="space-y-1">
+                <p className="font-medium text-[#021034]">
+                  {item.subject ?? "Class"}
+                </p>
+                <div className="flex flex-wrap items-center gap-3 text-sm text-[#737373]">
+                  <span>
+                    {item.startTime}
+                    {item.endTime ? `–${item.endTime}` : ""}
+                  </span>
+                  {item.subjectTeacher ? (
+                    <span>{item.subjectTeacher}</span>
+                  ) : null}
+                </div>
+              </div>
+              <div className="rounded-full border border-[#D7E3FC] bg-blue-50 px-4 py-1 text-xs font-semibold text-[#021034]">
+                {item.room ?? "—"}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {entries.length > 0 ? (
+        <Card className="mt-4">
+          <p className="text-sm text-slate-600">
+            Showing {entries.length} period
+            {entries.length === 1 ? "" : "s"} for the assigned class.
+          </p>
+        </Card>
+      ) : null}
+    </PortalPageShell>
+  );
+}

--- a/src/modules/parent-portal/components/ChildrenListView.tsx
+++ b/src/modules/parent-portal/components/ChildrenListView.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import Link from "next/link";
+import Button from "@/components/ui/Button";
+import { useParentChildrenQuery } from "@/modules/parent-portal/hooks/useParentPortal";
+import {
+  formatClassLabel,
+  formatErrorMessage,
+  PortalEmpty,
+  PortalError,
+  PortalLoading,
+  PortalPageHeader,
+  PortalPageShell,
+  RELATIONSHIP_LABELS,
+} from "@/modules/parent-portal/components/PortalState";
+
+export default function ChildrenListView() {
+  const { data, isLoading, error, refetch } = useParentChildrenQuery();
+  const children = data ?? [];
+
+  if (isLoading) return <PortalLoading rows={3} />;
+  if (error) {
+    return (
+      <PortalError
+        message={formatErrorMessage(error, "Failed to load children")}
+        onRetry={() => void refetch()}
+      />
+    );
+  }
+
+  return (
+    <PortalPageShell>
+      <PortalPageHeader
+        title="My Children"
+        description="Students linked to your parent account"
+      />
+
+      {children.length === 0 ? (
+        <PortalEmpty
+          title="No children linked"
+          description="Contact the school admin to link student profiles."
+        />
+      ) : (
+        <div className="divide-y divide-[#D7E3FC] rounded-lg border border-[#D7E3FC] bg-white">
+          {children.map((child) => (
+            <div
+              key={child.id}
+              className="flex flex-col justify-between gap-3 px-6 py-4 sm:flex-row sm:items-center"
+            >
+              <div>
+                <div className="font-medium text-slate-900">{child.fullName}</div>
+                <div className="text-sm text-slate-600">
+                  {formatClassLabel(child.className, child.section)}
+                  {child.studentCode ? ` · ${child.studentCode}` : ""}
+                </div>
+                <span className="mt-2 inline-flex rounded-md bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700">
+                  {RELATIONSHIP_LABELS[child.relationship] ??
+                    child.relationship}
+                </span>
+              </div>
+              <Link href={`/parent/children/${child.id}`}>
+                <Button variant="dark">View</Button>
+              </Link>
+            </div>
+          ))}
+        </div>
+      )}
+    </PortalPageShell>
+  );
+}

--- a/src/modules/parent-portal/components/ParentDashboardView.tsx
+++ b/src/modules/parent-portal/components/ParentDashboardView.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import Link from "next/link";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import {
+  useParentChildrenQuery,
+  useParentMeQuery,
+} from "@/modules/parent-portal/hooks/useParentPortal";
+import {
+  formatClassLabel,
+  formatErrorMessage,
+  PortalEmpty,
+  PortalError,
+  PortalLoading,
+  PortalPageHeader,
+  PortalPageShell,
+  RELATIONSHIP_LABELS,
+} from "@/modules/parent-portal/components/PortalState";
+
+export default function ParentDashboardView() {
+  const meQuery = useParentMeQuery();
+  const childrenQuery = useParentChildrenQuery();
+
+  const me = meQuery.data;
+  const children = childrenQuery.data ?? [];
+  const loading = meQuery.isLoading || childrenQuery.isLoading;
+  const error = meQuery.error || childrenQuery.error;
+
+  if (loading) return <PortalLoading rows={3} />;
+  if (error) {
+    return (
+      <PortalError
+        message={formatErrorMessage(error, "Failed to load dashboard")}
+        onRetry={() => {
+          void meQuery.refetch();
+          void childrenQuery.refetch();
+        }}
+      />
+    );
+  }
+
+  return (
+    <PortalPageShell>
+      <PortalPageHeader
+        title={`Welcome${me?.fullName ? `, ${me.fullName}` : ""}`}
+        description="View your linked children and follow their school activity."
+      />
+
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Card>
+          <div className="text-sm text-slate-500">Linked children</div>
+          <div className="mt-2 text-3xl font-semibold text-slate-900">
+            {children.length}
+          </div>
+        </Card>
+        <Card>
+          <div className="text-sm text-slate-500">Account email</div>
+          <div className="mt-2 text-lg font-medium text-slate-900">
+            {me?.email ?? "—"}
+          </div>
+        </Card>
+      </div>
+
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">My Children</h2>
+        <Link href="/parent/children">
+          <Button variant="ghost">View all</Button>
+        </Link>
+      </div>
+
+      {children.length === 0 ? (
+        <PortalEmpty
+          title="No children linked yet"
+          description="Ask your school admin to link your children to this parent account."
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {children.map((child) => (
+            <Card key={child.id}>
+              <div className="font-medium text-slate-900">{child.fullName}</div>
+              <div className="mt-1 text-sm text-slate-600">
+                {formatClassLabel(child.className, child.section)}
+              </div>
+              <div className="mt-1 text-xs text-slate-500">
+                {RELATIONSHIP_LABELS[child.relationship] ?? child.relationship}
+                {child.studentCode ? ` · ${child.studentCode}` : ""}
+              </div>
+              <div className="mt-4">
+                <Link href={`/parent/children/${child.id}`}>
+                  <Button variant="dark">Open dashboard</Button>
+                </Link>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </PortalPageShell>
+  );
+}

--- a/src/modules/parent-portal/components/PortalState.tsx
+++ b/src/modules/parent-portal/components/PortalState.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { Skeleton } from "@/components/ui/Skeleton";
+
+export function PortalPageShell({ children }: { children: React.ReactNode }) {
+  return <div className="mx-auto px-4 py-6">{children}</div>;
+}
+
+export function PortalPageHeader({
+  title,
+  description,
+  actions,
+}: {
+  title: string;
+  description?: string;
+  actions?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <h1 className="text-[24px] font-[600] text-[#021034]">{title}</h1>
+        {description ? (
+          <p className="mt-1 text-[14px] text-[#737373]">{description}</p>
+        ) : null}
+      </div>
+      {actions}
+    </div>
+  );
+}
+
+export function PortalLoading({ rows = 3 }: { rows?: number }) {
+  return (
+    <PortalPageShell>
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-64" />
+        <Skeleton className="h-4 w-80" />
+        {Array.from({ length: rows }).map((_, i) => (
+          <Skeleton key={i} className="h-28 w-full" />
+        ))}
+      </div>
+    </PortalPageShell>
+  );
+}
+
+export function PortalError({
+  message = "Something went wrong",
+  onRetry,
+}: {
+  message?: string;
+  onRetry?: () => void;
+}) {
+  return (
+    <PortalPageShell>
+      <Card>
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-slate-700">{message}</p>
+          {onRetry ? (
+            <Button variant="dark" onClick={onRetry}>
+              Retry
+            </Button>
+          ) : null}
+        </div>
+      </Card>
+    </PortalPageShell>
+  );
+}
+
+export function PortalEmpty({
+  title,
+  description,
+}: {
+  title: string;
+  description?: string;
+}) {
+  return (
+    <Card>
+      <div className="py-8 text-center">
+        <h3 className="text-base font-medium text-slate-900">{title}</h3>
+        {description ? (
+          <p className="mt-1 text-sm text-slate-600">{description}</p>
+        ) : null}
+      </div>
+    </Card>
+  );
+}
+
+export const RELATIONSHIP_LABELS: Record<string, string> = {
+  FATHER: "Father",
+  MOTHER: "Mother",
+  GUARDIAN: "Guardian",
+  OTHER: "Other",
+};
+
+export function formatClassLabel(
+  className?: string | null,
+  section?: string | null,
+): string {
+  const parts = [className, section].filter(Boolean);
+  return parts.length ? parts.join(" - ") : "Class not assigned";
+}
+
+export function formatErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (error && typeof error === "object" && "message" in error) {
+    const msg = (error as { message?: unknown }).message;
+    if (typeof msg === "string" && msg) return msg;
+  }
+  return fallback;
+}

--- a/src/modules/parent-portal/constants/query-keys.ts
+++ b/src/modules/parent-portal/constants/query-keys.ts
@@ -1,0 +1,64 @@
+export const PARENT_PORTAL_PAGE_SIZE = 10;
+
+export const parentPortalQueryKeys = {
+  all: ["parent-portal"] as const,
+  me: () => [...parentPortalQueryKeys.all, "me"] as const,
+  children: () => [...parentPortalQueryKeys.all, "children"] as const,
+  child: (studentId: string) =>
+    [...parentPortalQueryKeys.all, "child", studentId] as const,
+  dashboard: (studentId: string) =>
+    [...parentPortalQueryKeys.child(studentId), "dashboard"] as const,
+  profile: (studentId: string) =>
+    [...parentPortalQueryKeys.child(studentId), "profile"] as const,
+  attendance: (studentId: string, params?: Record<string, unknown>) =>
+    [...parentPortalQueryKeys.child(studentId), "attendance", params ?? {}] as const,
+  attendanceMonthly: (
+    studentId: string,
+    params?: { year?: number; month?: number },
+  ) =>
+    [
+      ...parentPortalQueryKeys.child(studentId),
+      "attendance-monthly",
+      params ?? {},
+    ] as const,
+  classInfo: (studentId: string) =>
+    [...parentPortalQueryKeys.child(studentId), "class"] as const,
+  timetable: (studentId: string) =>
+    [...parentPortalQueryKeys.child(studentId), "timetable"] as const,
+  announcements: (studentId: string, params?: Record<string, unknown>) =>
+    [
+      ...parentPortalQueryKeys.child(studentId),
+      "announcements",
+      params ?? {},
+    ] as const,
+  documents: (studentId: string) =>
+    [...parentPortalQueryKeys.child(studentId), "documents"] as const,
+  homework: (studentId: string, params?: Record<string, unknown>) =>
+    [...parentPortalQueryKeys.child(studentId), "homework", params ?? {}] as const,
+  homeworkDetail: (studentId: string, homeworkId: string) =>
+    [
+      ...parentPortalQueryKeys.child(studentId),
+      "homework",
+      homeworkId,
+    ] as const,
+  fees: (studentId: string, params?: Record<string, unknown>) =>
+    [...parentPortalQueryKeys.child(studentId), "fees", params ?? {}] as const,
+  feesSummary: (studentId: string) =>
+    [...parentPortalQueryKeys.child(studentId), "fees-summary"] as const,
+  feePayments: (studentId: string, params?: Record<string, unknown>) =>
+    [
+      ...parentPortalQueryKeys.child(studentId),
+      "fee-payments",
+      params ?? {},
+    ] as const,
+  exams: (studentId: string) =>
+    [...parentPortalQueryKeys.child(studentId), "exams"] as const,
+  examSchedule: (studentId: string) =>
+    [...parentPortalQueryKeys.child(studentId), "exam-schedule"] as const,
+  reportCard: (studentId: string, examId: string) =>
+    [
+      ...parentPortalQueryKeys.child(studentId),
+      "report-card",
+      examId,
+    ] as const,
+};

--- a/src/modules/parent-portal/hooks/useParentPortal.ts
+++ b/src/modules/parent-portal/hooks/useParentPortal.ts
@@ -1,0 +1,198 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  fetchChildAnnouncements,
+  fetchChildAttendance,
+  fetchChildClass,
+  fetchChildDashboard,
+  fetchChildDocuments,
+  fetchChildExamResults,
+  fetchChildExamSchedule,
+  fetchChildFeePayments,
+  fetchChildFees,
+  fetchChildFeesSummary,
+  fetchChildHomework,
+  fetchChildHomeworkDetail,
+  fetchChildMonthlyAttendance,
+  fetchChildProfile,
+  fetchChildReportCard,
+  fetchChildTimetable,
+  fetchParentChildren,
+  fetchParentMe,
+} from "@/modules/parent-portal/api/parentPortal";
+import {
+  PARENT_PORTAL_PAGE_SIZE,
+  parentPortalQueryKeys,
+} from "@/modules/parent-portal/constants/query-keys";
+import type { HomeworkQuery } from "@/modules/parent-portal/types";
+
+export function useParentMeQuery() {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.me(),
+    queryFn: fetchParentMe,
+  });
+}
+
+export function useParentChildrenQuery() {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.children(),
+    queryFn: fetchParentChildren,
+  });
+}
+
+export function useChildDashboardQuery(studentId: string | undefined) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.dashboard(studentId ?? ""),
+    queryFn: () => fetchChildDashboard(studentId!),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildProfileQuery(studentId: string | undefined) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.profile(studentId ?? ""),
+    queryFn: () => fetchChildProfile(studentId!),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildAttendanceQuery(
+  studentId: string | undefined,
+  params?: { from?: string; to?: string },
+) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.attendance(studentId ?? "", params),
+    queryFn: () => fetchChildAttendance(studentId!, params),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildMonthlyAttendanceQuery(
+  studentId: string | undefined,
+  params?: { year?: number; month?: number },
+) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.attendanceMonthly(studentId ?? "", params),
+    queryFn: () => fetchChildMonthlyAttendance(studentId!, params),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildClassQuery(studentId: string | undefined) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.classInfo(studentId ?? ""),
+    queryFn: () => fetchChildClass(studentId!),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildTimetableQuery(studentId: string | undefined) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.timetable(studentId ?? ""),
+    queryFn: () => fetchChildTimetable(studentId!),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildAnnouncementsQuery(
+  studentId: string | undefined,
+  params?: { page?: number; limit?: number },
+) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.announcements(studentId ?? "", params),
+    queryFn: () => fetchChildAnnouncements(studentId!, params),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildDocumentsQuery(studentId: string | undefined) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.documents(studentId ?? ""),
+    queryFn: () => fetchChildDocuments(studentId!),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildHomeworkQuery(
+  studentId: string | undefined,
+  query: HomeworkQuery = {},
+) {
+  const q = { page: 1, limit: PARENT_PORTAL_PAGE_SIZE, ...query };
+  return useQuery({
+    queryKey: parentPortalQueryKeys.homework(studentId ?? "", q),
+    queryFn: () => fetchChildHomework(studentId!, q),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildHomeworkDetailQuery(
+  studentId: string | undefined,
+  homeworkId: string | undefined,
+) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.homeworkDetail(
+      studentId ?? "",
+      homeworkId ?? "",
+    ),
+    queryFn: () => fetchChildHomeworkDetail(studentId!, homeworkId!),
+    enabled: Boolean(studentId && homeworkId),
+  });
+}
+
+export function useChildFeesQuery(
+  studentId: string | undefined,
+  params?: { page?: number; limit?: number; status?: string },
+) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.fees(studentId ?? "", params),
+    queryFn: () => fetchChildFees(studentId!, params),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildFeesSummaryQuery(studentId: string | undefined) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.feesSummary(studentId ?? ""),
+    queryFn: () => fetchChildFeesSummary(studentId!),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildFeePaymentsQuery(
+  studentId: string | undefined,
+  params?: { page?: number; limit?: number },
+) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.feePayments(studentId ?? "", params),
+    queryFn: () => fetchChildFeePayments(studentId!, params),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildExamResultsQuery(studentId: string | undefined) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.exams(studentId ?? ""),
+    queryFn: () => fetchChildExamResults(studentId!),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildExamScheduleQuery(studentId: string | undefined) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.examSchedule(studentId ?? ""),
+    queryFn: () => fetchChildExamSchedule(studentId!),
+    enabled: Boolean(studentId),
+  });
+}
+
+export function useChildReportCardQuery(
+  studentId: string | undefined,
+  examId: string | undefined,
+) {
+  return useQuery({
+    queryKey: parentPortalQueryKeys.reportCard(studentId ?? "", examId ?? ""),
+    queryFn: () => fetchChildReportCard(studentId!, examId!),
+    enabled: Boolean(studentId && examId),
+  });
+}

--- a/src/modules/parent-portal/index.ts
+++ b/src/modules/parent-portal/index.ts
@@ -1,0 +1,22 @@
+export * from "./types";
+export * from "./api/parentPortal";
+export * from "./hooks/useParentPortal";
+export {
+  PARENT_PORTAL_PAGE_SIZE,
+  parentPortalQueryKeys,
+} from "./constants/query-keys";
+
+export { default as ChildSwitcher } from "./components/ChildSwitcher";
+export { default as ChildSubnav } from "./components/ChildSubnav";
+export { default as ParentDashboardView } from "./components/ParentDashboardView";
+export { default as ChildrenListView } from "./components/ChildrenListView";
+export { default as ChildDashboardView } from "./components/ChildDashboardView";
+export { default as ChildProfileView } from "./components/ChildProfileView";
+export { default as ChildAttendanceView } from "./components/ChildAttendanceView";
+export { default as ChildTimetableView } from "./components/ChildTimetableView";
+export { default as ChildHomeworkListView } from "./components/ChildHomeworkListView";
+export { default as ChildHomeworkDetailView } from "./components/ChildHomeworkDetailView";
+export { default as ChildFeesView } from "./components/ChildFeesView";
+export { default as ChildExamsView } from "./components/ChildExamsView";
+export { default as ChildAnnouncementsView } from "./components/ChildAnnouncementsView";
+export { default as ChildDocumentsView } from "./components/ChildDocumentsView";

--- a/src/modules/parent-portal/types/index.ts
+++ b/src/modules/parent-portal/types/index.ts
@@ -1,0 +1,194 @@
+import type { EntityDocument } from "@/modules/documents/types";
+import type { Exam, ExamResult, ExamSchedule, ReportCard } from "@/modules/exams/types";
+import type { FeePayment, Paginated, StudentFee } from "@/modules/fees/types";
+import type {
+  Homework,
+  HomeworkQuery,
+  StudentHomeworkDetail,
+} from "@/modules/homework/types";
+
+export type ParentRelationship =
+  | "FATHER"
+  | "MOTHER"
+  | "GUARDIAN"
+  | "OTHER";
+
+export type ParentMe = {
+  id: string;
+  fullName: string;
+  email: string;
+  mobile?: string | null;
+};
+
+export type ParentChild = {
+  id: string;
+  fullName: string;
+  studentCode?: string | null;
+  classId?: string | null;
+  className?: string | null;
+  section?: string | null;
+  relationship: ParentRelationship;
+};
+
+export type ChildClassInfo = {
+  id: string;
+  name: string;
+  section?: string | null;
+} | null;
+
+export type ChildDashboard = {
+  totalDays: number;
+  presentDays: number;
+  absentDays: number;
+  leaveDays: number;
+  attendancePercentage: number;
+  profile?: {
+    id: string;
+    fullName: string;
+    studentCode: string | null;
+    class: ChildClassInfo;
+  };
+  currentClass?: ChildClassInfo;
+  timetable?: ChildTimetableEntry[];
+  recentAnnouncements?: ChildAnnouncementItem[];
+  documents?: {
+    count: number;
+    items: EntityDocument[];
+  };
+};
+
+export type ChildTimetableEntry = {
+  subject: string | null;
+  startTime: string;
+  endTime: string;
+  subjectTeacher: string | null;
+  room: string | null;
+  dayOfWeek?: number | string | null;
+};
+
+export type ChildAnnouncementItem = {
+  id: string;
+  title: string;
+  body: string;
+  publishedAt: string | Date;
+  authorName: string | null;
+  pinned?: boolean;
+};
+
+export type ChildAnnouncementsPage = {
+  total: number;
+  page: number;
+  limit: number;
+  items: ChildAnnouncementItem[];
+};
+
+export type ChildAttendanceRecord = {
+  date: string;
+  status: string;
+  note?: string | null;
+};
+
+export type ChildMonthlyAttendance = {
+  studentId: string;
+  year: number;
+  month: number;
+  totalDays: number;
+  present: number;
+  absent: number;
+  leave: number;
+  percentage: number;
+  details: ChildAttendanceRecord[];
+};
+
+/** Raw shape from parent profile endpoint (service returns user + profile). */
+export type ChildProfileRaw = {
+  user?: {
+    id?: string;
+    fullName?: string | null;
+    email?: string | null;
+    mobile?: string | null;
+    address?: string | null;
+    gender?: string | null;
+    dateOfBirth?: string | Date | null;
+    studentCode?: string | null;
+    status?: string | null;
+  };
+  profile?: {
+    bloodGroup?: string | null;
+    aadhaarNumber?: string | null;
+    fatherName?: string | null;
+    fatherMobile?: string | null;
+    motherName?: string | null;
+    motherMobile?: string | null;
+    guardianName?: string | null;
+    guardianMobile?: string | null;
+    medicalNotes?: string | null;
+    currentClass?: {
+      id?: string;
+      name?: string;
+      section?: string | null;
+    } | null;
+  };
+  documents?: EntityDocument[];
+  /** Flattened fields if API ever maps like student portal */
+  id?: string;
+  fullName?: string | null;
+  dob?: string | Date | null;
+  gender?: string | null;
+  bloodGroup?: string | null;
+  aadhaarNumber?: string | null;
+  phoneNumber?: string | null;
+  email?: string | null;
+  address?: string | null;
+  fatherName?: string | null;
+  fatherMobile?: string | null;
+  motherName?: string | null;
+  motherMobile?: string | null;
+  guardianName?: string | null;
+  guardianMobile?: string | null;
+  studentCode?: string | null;
+  class?: {
+    id?: string;
+    name?: string;
+    section?: string | null;
+  } | null;
+};
+
+export type ChildProfile = {
+  id: string;
+  fullName: string;
+  studentCode: string | null;
+  dob: string | null;
+  gender: string | null;
+  bloodGroup: string | null;
+  aadhaarNumber: string | null;
+  phone: string | null;
+  email: string | null;
+  address: string | null;
+  fatherName: string | null;
+  fatherMobile: string | null;
+  motherName: string | null;
+  motherMobile: string | null;
+  guardianName: string | null;
+  guardianMobile: string | null;
+  medicalNotes: string | null;
+  class: ChildClassInfo;
+  documents: EntityDocument[];
+};
+
+export type ChildFeeSummary = {
+  totalOutstanding: number;
+  totalPaid: number;
+  overdueCount: number;
+  pendingCount: number;
+  totalAssignments: number;
+};
+
+export type ChildExamScheduleGroup = {
+  exam: Exam;
+  schedules: ExamSchedule[];
+};
+
+export type { Homework, HomeworkQuery, StudentHomeworkDetail };
+export type { StudentFee, FeePayment, Paginated };
+export type { ExamResult, ReportCard, EntityDocument };

--- a/src/modules/parents/api/adminParents.ts
+++ b/src/modules/parents/api/adminParents.ts
@@ -1,0 +1,80 @@
+import { ADMIN_API } from "@/config/api-routes";
+import API from "@/services/axios";
+import type {
+  CreateParentPayload,
+  CreateParentResponse,
+  LinkChildrenPayload,
+  Parent,
+  ParentsQuery,
+  ParentsResponse,
+  UpdateParentPayload,
+} from "@/modules/parents/types";
+
+export async function fetchParents(
+  query: ParentsQuery = {},
+): Promise<ParentsResponse> {
+  const params: Record<string, string | number> = {};
+  if (query.search) params.search = query.search;
+  if (query.status) params.status = query.status;
+  if (query.page) params.page = query.page;
+  if (query.pageSize) params.limit = query.pageSize;
+
+  const res = await API.get<{
+    data?: Parent[];
+    total?: number;
+    page?: number;
+    limit?: number;
+  }>(ADMIN_API.PARENTS, { params });
+
+  const {
+    data = [],
+    total = 0,
+    page = query.page ?? 1,
+    limit = query.pageSize ?? 10,
+  } = res.data ?? {};
+
+  return {
+    parents: data,
+    total,
+    page,
+    pageSize: limit,
+  };
+}
+
+export async function getParentById(id: string): Promise<Parent> {
+  const res = await API.get<Parent>(ADMIN_API.PARENT_BY_ID(id));
+  return res.data;
+}
+
+export async function createParent(
+  payload: CreateParentPayload,
+): Promise<CreateParentResponse> {
+  const res = await API.post<CreateParentResponse>(ADMIN_API.PARENTS, payload);
+  return res.data;
+}
+
+export async function updateParent(
+  id: string,
+  payload: UpdateParentPayload,
+): Promise<Parent> {
+  const res = await API.patch<Parent>(ADMIN_API.PARENT_BY_ID(id), payload);
+  return res.data;
+}
+
+export async function linkChildren(
+  parentId: string,
+  payload: LinkChildrenPayload,
+): Promise<Parent> {
+  const res = await API.post<Parent>(
+    ADMIN_API.PARENT_CHILDREN(parentId),
+    payload,
+  );
+  return res.data;
+}
+
+export async function unlinkChild(
+  parentId: string,
+  studentId: string,
+): Promise<void> {
+  await API.delete(ADMIN_API.PARENT_UNLINK_CHILD(parentId, studentId));
+}

--- a/src/modules/parents/api/portal.ts
+++ b/src/modules/parents/api/portal.ts
@@ -1,0 +1,6 @@
+/** @deprecated Prefer `@/modules/parent-portal` */
+export {
+  fetchParentMe,
+  fetchParentChildren,
+} from "@/modules/parent-portal/api/parentPortal";
+export type { ParentMe } from "@/modules/parent-portal/types";

--- a/src/modules/parents/components/CreateParentDialog.tsx
+++ b/src/modules/parents/components/CreateParentDialog.tsx
@@ -1,0 +1,382 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  useForm,
+  type FieldErrors,
+  type SubmitHandler,
+} from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import axios from "axios";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import Form, {
+  FormField,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/Form";
+import { Input } from "@/components/ui/Input";
+import Select from "@/components/ui/Select";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  createParentSchema,
+  type CreateParentValues,
+} from "@/modules/parents/schemas/parent.schemas";
+import { useParentMutations } from "@/modules/parents/hooks/useParents";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onCreated?: () => void;
+};
+
+export default function CreateParentDialog({
+  open,
+  onClose,
+  onCreated,
+}: Props) {
+  const { toast } = useToast();
+  const { create } = useParentMutations();
+  const [tempEmail, setTempEmail] = useState<string | null>(null);
+  const [tempPassword, setTempPassword] = useState<string | null>(null);
+
+  const form = useForm<CreateParentValues>({
+    resolver: zodResolver(createParentSchema) as any,
+    mode: "onSubmit",
+    reValidateMode: "onChange",
+    defaultValues: {
+      firstName: "",
+      lastName: "",
+      email: "",
+      mobile: "",
+      address: "",
+      gender: undefined,
+      dateOfBirth: "",
+    },
+  });
+
+  const {
+    handleSubmit,
+    setError,
+    reset,
+    register,
+    formState: { errors, isSubmitting },
+  } = form;
+
+  useEffect(() => {
+    if (!open) {
+      reset();
+      setTempEmail(null);
+      setTempPassword(null);
+    }
+  }, [open, reset]);
+
+  const onSubmit: SubmitHandler<CreateParentValues> = useCallback(
+    async (values) => {
+      try {
+        const digits = values.mobile.replace(/[^0-9]/g, "");
+        const mobile =
+          digits.length === 10 ? `+91${digits}` : values.mobile.startsWith("+")
+            ? values.mobile.replace(/[\s-]/g, "")
+            : `+${digits}`;
+
+        const res = await create.mutateAsync({
+          firstName: values.firstName,
+          lastName: values.lastName,
+          email: values.email,
+          mobile,
+          address: values.address || undefined,
+          gender: values.gender,
+          dateOfBirth: values.dateOfBirth || undefined,
+        });
+
+        setTempEmail(res.email ?? values.email);
+        setTempPassword(res.temporaryPassword ?? null);
+        toast({
+          title: "Parent created",
+          description: "Temporary credentials generated.",
+          type: "success",
+        });
+        reset();
+        onCreated?.();
+      } catch (err) {
+        if (axios.isAxiosError(err)) {
+          const data = err.response?.data as Record<string, unknown> | undefined;
+          if (data?.errors && typeof data.errors === "object") {
+            Object.entries(data.errors as Record<string, string>).forEach(
+              ([k, v]) => {
+                setError(k as keyof CreateParentValues, {
+                  type: "server",
+                  message: String(v),
+                });
+              },
+            );
+            toast({
+              title: "Validation error",
+              description: "Please fix the form errors.",
+              type: "error",
+            });
+            return;
+          }
+          toast({
+            title: "Failed to create parent",
+            description: String(data?.message ?? err.message),
+            type: "error",
+          });
+          return;
+        }
+        toast({
+          title: "Failed to create parent",
+          description: (err as Error)?.message ?? "Unknown error",
+          type: "error",
+        });
+      }
+    },
+    [create, onCreated, reset, setError, toast],
+  );
+
+  const onInvalid = useCallback(
+    (fieldErrors: FieldErrors<CreateParentValues>) => {
+      const firstError = Object.values(fieldErrors).find((e) => e?.message);
+      toast({
+        title: "Please fix the form errors",
+        description:
+          (firstError?.message as string) ??
+          "Some required fields are missing or invalid.",
+        type: "error",
+      });
+    },
+    [toast],
+  );
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-50 flex items-center justify-center">
+        <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+        <div className="relative w-full max-w-xl p-4 max-h-full overflow-y-auto">
+          <div className="rounded-lg overflow-hidden">
+            <div className="flex items-start bg-[#021034] rounded-t-lg py-[24px] px-[16px] justify-between gap-4">
+              <div>
+                <h3 className="text-[24px] font-[700] text-white">
+                  Create New Parent
+                </h3>
+                <p className="text-[14px] font-[400] text-white">
+                  Fill in the details below to add a parent account.
+                </p>
+              </div>
+              <button
+                aria-label="close"
+                onClick={onClose}
+                className="text-white hover:text-white/80"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="p-[16px] bg-white rounded-b-lg">
+              <Form onSubmit={handleSubmit(onSubmit, onInvalid)}>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField>
+                    <FormLabel>First Name</FormLabel>
+                    <FormMessage>
+                      {errors.firstName?.message as React.ReactNode}
+                    </FormMessage>
+                    <FormControl>
+                      <Input
+                        {...register("firstName")}
+                        placeholder="First name"
+                      />
+                    </FormControl>
+                  </FormField>
+                  <FormField>
+                    <FormLabel>Last Name</FormLabel>
+                    <FormMessage>
+                      {errors.lastName?.message as React.ReactNode}
+                    </FormMessage>
+                    <FormControl>
+                      <Input
+                        {...register("lastName")}
+                        placeholder="Last name"
+                      />
+                    </FormControl>
+                  </FormField>
+                  <FormField>
+                    <FormLabel>Email</FormLabel>
+                    <FormMessage>
+                      {errors.email?.message as React.ReactNode}
+                    </FormMessage>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        {...register("email")}
+                        placeholder="parent@example.com"
+                      />
+                    </FormControl>
+                  </FormField>
+                  <FormField>
+                    <FormLabel>Mobile</FormLabel>
+                    <FormMessage>
+                      {errors.mobile?.message as React.ReactNode}
+                    </FormMessage>
+                    <FormControl>
+                      <Input
+                        {...register("mobile")}
+                        placeholder="10-digit mobile"
+                      />
+                    </FormControl>
+                  </FormField>
+                  <FormField>
+                    <FormLabel>Gender (optional)</FormLabel>
+                    <FormControl>
+                      <Select
+                        options={[
+                          { id: "", name: "Select gender" },
+                          { id: "MALE", name: "Male" },
+                          { id: "FEMALE", name: "Female" },
+                          { id: "OTHER", name: "Other" },
+                        ]}
+                        value={form.watch("gender") ?? ""}
+                        onChange={(v) =>
+                          form.setValue(
+                            "gender",
+                            v
+                              ? (v as "MALE" | "FEMALE" | "OTHER")
+                              : undefined,
+                            { shouldValidate: true },
+                          )
+                        }
+                        placeholder="Select gender"
+                        className="w-full"
+                      />
+                    </FormControl>
+                  </FormField>
+                  <FormField>
+                    <FormLabel>Date of Birth (optional)</FormLabel>
+                    <FormMessage>
+                      {errors.dateOfBirth?.message as React.ReactNode}
+                    </FormMessage>
+                    <FormControl>
+                      <Input type="date" {...register("dateOfBirth")} />
+                    </FormControl>
+                  </FormField>
+                  <div className="sm:col-span-2">
+                    <FormField>
+                      <FormLabel>Address (optional)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...register("address")}
+                          placeholder="Address"
+                        />
+                      </FormControl>
+                    </FormField>
+                  </div>
+                </div>
+
+                <div className="mt-6 flex justify-end gap-2">
+                  <Button type="button" variant="ghost" onClick={onClose}>
+                    Cancel
+                  </Button>
+                  <Button
+                    type="submit"
+                    variant="dark"
+                    disabled={isSubmitting || create.isPending}
+                  >
+                    {isSubmitting || create.isPending
+                      ? "Saving…"
+                      : "Create Parent"}
+                  </Button>
+                </div>
+              </Form>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {tempEmail || tempPassword ? (
+        <div className="fixed inset-0 z-60 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/40" />
+          <div className="relative w-full max-w-md p-4">
+            <Card>
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-lg font-semibold text-slate-900">
+                    Temporary Credentials
+                  </h3>
+                  <p className="mt-1 text-sm text-slate-600">
+                    Share these credentials with the parent — they will not be
+                    shown again.
+                  </p>
+                </div>
+                <button
+                  aria-label="close"
+                  onClick={() => {
+                    setTempEmail(null);
+                    setTempPassword(null);
+                    onClose();
+                  }}
+                  className="text-slate-500 hover:text-slate-700"
+                >
+                  ✕
+                </button>
+              </div>
+
+              <div className="mt-4">
+                <div className="rounded-md border p-4">
+                  <div className="text-sm text-slate-700">Email</div>
+                  <div className="mt-2 flex items-center gap-3">
+                    <div className="font-mono text-lg text-slate-900">
+                      {tempEmail ?? "-"}
+                    </div>
+                    <Button
+                      variant="ghost"
+                      onClick={async () => {
+                        const parts: string[] = [];
+                        if (tempEmail) parts.push(`Email: ${tempEmail}`);
+                        if (tempPassword)
+                          parts.push(`Temporary Password: ${tempPassword}`);
+                        try {
+                          await navigator.clipboard.writeText(parts.join("\n"));
+                          toast({
+                            title: "Copied to clipboard",
+                            type: "success",
+                          });
+                        } catch {
+                          toast({ title: "Copy failed", type: "error" });
+                        }
+                      }}
+                    >
+                      Copy
+                    </Button>
+                  </div>
+                  {tempPassword ? (
+                    <>
+                      <div className="mt-4 text-sm text-slate-700">
+                        Temporary Password
+                      </div>
+                      <div className="mt-2 font-mono text-lg text-slate-900">
+                        {tempPassword}
+                      </div>
+                    </>
+                  ) : null}
+                </div>
+                <div className="mt-4 flex justify-end">
+                  <Button
+                    onClick={() => {
+                      setTempEmail(null);
+                      setTempPassword(null);
+                      onClose();
+                    }}
+                  >
+                    Close
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/modules/parents/components/LinkChildrenDialog.tsx
+++ b/src/modules/parents/components/LinkChildrenDialog.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import Select from "@/components/ui/Select";
+import { useToast } from "@/components/ui/use-toast";
+import { fetchStudents } from "@/modules/students/api/adminStudents";
+import type { Student } from "@/modules/students/types/admin";
+import { PARENT_RELATIONSHIP_OPTIONS } from "@/modules/parents/schemas/parent.schemas";
+import { useParentMutations } from "@/modules/parents/hooks/useParents";
+import type { ParentRelationship } from "@/modules/parents/types";
+
+type Props = {
+  open: boolean;
+  parentId: string;
+  alreadyLinkedIds?: string[];
+  onClose: () => void;
+  onLinked?: () => void;
+};
+
+type SelectedChild = {
+  studentUserId: string;
+  name: string;
+  relationship: ParentRelationship;
+};
+
+export default function LinkChildrenDialog({
+  open,
+  parentId,
+  alreadyLinkedIds = [],
+  onClose,
+  onLinked,
+}: Props) {
+  const { toast } = useToast();
+  const { link } = useParentMutations();
+  const [search, setSearch] = useState("");
+  const [students, setStudents] = useState<Student[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState<SelectedChild[]>([]);
+  const [defaultRelationship, setDefaultRelationship] =
+    useState<ParentRelationship>("GUARDIAN");
+
+  const linkedSet = useMemo(
+    () => new Set(alreadyLinkedIds),
+    [alreadyLinkedIds],
+  );
+
+  const selectedIds = useMemo(
+    () => new Set(selected.map((s) => s.studentUserId)),
+    [selected],
+  );
+
+  useEffect(() => {
+    if (!open) {
+      setSearch("");
+      setStudents([]);
+      setSelected([]);
+      setDefaultRelationship("GUARDIAN");
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    let mounted = true;
+    const t = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const resp = await fetchStudents({
+          search: search.trim() || undefined,
+          page: 1,
+          pageSize: 20,
+        });
+        if (!mounted) return;
+        setStudents(resp.students ?? []);
+      } catch (err) {
+        if (!mounted) return;
+        toast({
+          title: "Failed to load students",
+          description: (err as Error)?.message ?? "Unknown error",
+          type: "error",
+        });
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    }, 350);
+    return () => {
+      mounted = false;
+      clearTimeout(t);
+    };
+  }, [open, search, toast]);
+
+  const toggleStudent = useCallback(
+    (student: Student) => {
+      if (linkedSet.has(student.id)) return;
+      setSelected((prev) => {
+        if (prev.some((s) => s.studentUserId === student.id)) {
+          return prev.filter((s) => s.studentUserId !== student.id);
+        }
+        return [
+          ...prev,
+          {
+            studentUserId: student.id,
+            name: student.name,
+            relationship: defaultRelationship,
+          },
+        ];
+      });
+    },
+    [defaultRelationship, linkedSet],
+  );
+
+  const updateRelationship = (
+    studentUserId: string,
+    relationship: ParentRelationship,
+  ) => {
+    setSelected((prev) =>
+      prev.map((s) =>
+        s.studentUserId === studentUserId ? { ...s, relationship } : s,
+      ),
+    );
+  };
+
+  const handleSubmit = async () => {
+    if (selected.length === 0) {
+      toast({
+        title: "Select at least one child",
+        type: "error",
+      });
+      return;
+    }
+    try {
+      await link.mutateAsync({
+        parentId,
+        payload: {
+          children: selected.map((s) => ({
+            studentUserId: s.studentUserId,
+            relationship: s.relationship,
+          })),
+        },
+      });
+      toast({
+        title: "Children linked",
+        description: `${selected.length} child(ren) linked successfully.`,
+        type: "success",
+      });
+      onLinked?.();
+      onClose();
+    } catch (err) {
+      toast({
+        title: "Failed to link children",
+        description: (err as Error)?.message ?? "Unknown error",
+        type: "error",
+      });
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative w-full max-w-2xl p-4 max-h-[90vh] overflow-y-auto">
+        <div className="rounded-lg overflow-hidden bg-white">
+          <div className="flex items-start bg-[#021034] py-[24px] px-[16px] justify-between gap-4">
+            <div>
+              <h3 className="text-[24px] font-[700] text-white">
+                Link Children
+              </h3>
+              <p className="text-[14px] font-[400] text-white">
+                Search students and link them to this parent.
+              </p>
+            </div>
+            <button
+              aria-label="close"
+              onClick={onClose}
+              className="text-white hover:text-white/80"
+            >
+              ✕
+            </button>
+          </div>
+
+          <div className="p-4 space-y-4">
+            <div className="flex flex-col sm:flex-row gap-3">
+              <div className="flex-1">
+                <Input
+                  className="bg-[#F5F9FF]"
+                  placeholder="Search students by name"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                />
+              </div>
+              <Select
+                className="min-w-40 bg-[#F5F9FF]"
+                options={[...PARENT_RELATIONSHIP_OPTIONS]}
+                value={defaultRelationship}
+                onChange={(v) =>
+                  setDefaultRelationship(v as ParentRelationship)
+                }
+                placeholder="Default relationship"
+              />
+            </div>
+
+            {selected.length > 0 ? (
+              <Card>
+                <h4 className="text-sm font-semibold text-slate-900 mb-2">
+                  Selected ({selected.length})
+                </h4>
+                <ul className="space-y-2">
+                  {selected.map((s) => (
+                    <li
+                      key={s.studentUserId}
+                      className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 border-b border-slate-100 pb-2 last:border-0"
+                    >
+                      <span className="text-sm text-slate-800">{s.name}</span>
+                      <div className="flex items-center gap-2">
+                        <Select
+                          className="min-w-36"
+                          options={[...PARENT_RELATIONSHIP_OPTIONS]}
+                          value={s.relationship}
+                          onChange={(v) =>
+                            updateRelationship(
+                              s.studentUserId,
+                              v as ParentRelationship,
+                            )
+                          }
+                        />
+                        <Button
+                          variant="ghost"
+                          onClick={() =>
+                            setSelected((prev) =>
+                              prev.filter(
+                                (x) => x.studentUserId !== s.studentUserId,
+                              ),
+                            )
+                          }
+                        >
+                          Remove
+                        </Button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            ) : null}
+
+            <div className="rounded-lg border border-[#D7E3FC] max-h-64 overflow-y-auto">
+              {loading ? (
+                <div className="p-4 text-sm text-slate-500">Loading…</div>
+              ) : students.length === 0 ? (
+                <div className="p-4 text-sm text-slate-500">
+                  No students found.
+                </div>
+              ) : (
+                <ul>
+                  {students.map((student) => {
+                    const already = linkedSet.has(student.id);
+                    const isSelected = selectedIds.has(student.id);
+                    return (
+                      <li
+                        key={student.id}
+                        className={`flex items-center justify-between gap-3 px-4 py-3 border-b border-[#D7E3FC] last:border-0 ${
+                          already ? "opacity-50" : "hover:bg-slate-50"
+                        }`}
+                      >
+                        <div>
+                          <div className="text-sm font-medium text-slate-900">
+                            {student.name}
+                          </div>
+                          <div className="text-xs text-slate-500">
+                            {[student.className, student.section]
+                              .filter(Boolean)
+                              .join(" - ") || "No class"}
+                            {student.studentId
+                              ? ` · ${student.studentId}`
+                              : ""}
+                          </div>
+                        </div>
+                        <Button
+                          variant={isSelected ? "dark" : "ghost"}
+                          disabled={already}
+                          onClick={() => toggleStudent(student)}
+                        >
+                          {already
+                            ? "Linked"
+                            : isSelected
+                              ? "Selected"
+                              : "Select"}
+                        </Button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="ghost" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button
+                variant="dark"
+                onClick={() => void handleSubmit()}
+                disabled={link.isPending || selected.length === 0}
+              >
+                {link.isPending ? "Linking…" : "Link Children"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/parents/components/ParentDetailView.tsx
+++ b/src/modules/parents/components/ParentDetailView.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import React, { useState } from "react";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useToast } from "@/components/ui/use-toast";
+import type { Parent } from "@/modules/parents/types";
+import { useParentMutations } from "@/modules/parents/hooks/useParents";
+import LinkChildrenDialog from "./LinkChildrenDialog";
+
+type Props = {
+  parent: Parent;
+  loading?: boolean;
+  onChanged?: () => void;
+};
+
+function formatRelationship(value: string) {
+  return value.charAt(0) + value.slice(1).toLowerCase();
+}
+
+export default function ParentDetailView({
+  parent,
+  loading,
+  onChanged,
+}: Props) {
+  const { toast } = useToast();
+  const { unlink } = useParentMutations();
+  const [linkOpen, setLinkOpen] = useState(false);
+  const [unlinkingId, setUnlinkingId] = useState<string | null>(null);
+
+  const children = parent.children ?? [];
+  const linkedIds = children.map((c) => c.id);
+
+  const handleUnlink = async (studentId: string, name: string) => {
+    const confirmed = window.confirm(
+      `Unlink ${name} from this parent? This can be re-linked later.`,
+    );
+    if (!confirmed) return;
+
+    setUnlinkingId(studentId);
+    try {
+      await unlink.mutateAsync({ parentId: parent.id, studentId });
+      toast({
+        title: "Child unlinked",
+        description: `${name} was removed from this parent.`,
+        type: "success",
+      });
+      onChanged?.();
+    } catch (err) {
+      toast({
+        title: "Failed to unlink",
+        description: (err as Error)?.message ?? "Unknown error",
+        type: "error",
+      });
+    } finally {
+      setUnlinkingId(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-slate-900">
+              {parent.fullName || `${parent.firstName} ${parent.lastName}`}
+            </h2>
+            <p className="mt-1 text-sm text-slate-600">{parent.email}</p>
+          </div>
+          <span className="inline-flex self-start rounded-md bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700">
+            {parent.status}
+          </span>
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-sm">
+          <div>
+            <div className="text-slate-500">Mobile</div>
+            <div className="mt-1 font-medium text-slate-900">
+              {parent.mobile ?? "-"}
+            </div>
+          </div>
+          <div>
+            <div className="text-slate-500">Gender</div>
+            <div className="mt-1 font-medium text-slate-900">
+              {parent.gender
+                ? formatRelationship(parent.gender)
+                : "-"}
+            </div>
+          </div>
+          <div>
+            <div className="text-slate-500">Children linked</div>
+            <div className="mt-1 font-medium text-slate-900">
+              {parent.childrenCount ?? children.length}
+            </div>
+          </div>
+          <div className="sm:col-span-2 lg:col-span-3">
+            <div className="text-slate-500">Address</div>
+            <div className="mt-1 font-medium text-slate-900">
+              {parent.address ?? "-"}
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">
+            Linked Children
+          </h3>
+          <p className="text-sm text-slate-600">
+            Manage which students this parent can access.
+          </p>
+        </div>
+        <Button variant="dark" onClick={() => setLinkOpen(true)}>
+          + Link Children
+        </Button>
+      </div>
+
+      {children.length === 0 ? (
+        <Card>
+          <div className="text-center py-4">
+            <h4 className="text-base font-medium text-slate-900">
+              No children linked
+            </h4>
+            <p className="mt-1 text-sm text-slate-600">
+              Link one or more students to this parent account.
+            </p>
+            <div className="mt-4">
+              <Button variant="dark" onClick={() => setLinkOpen(true)}>
+                Link Children
+              </Button>
+            </div>
+          </div>
+        </Card>
+      ) : (
+        <div className="rounded-lg bg-white border border-[#D7E3FC]">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="pl-6">Student</TableHead>
+                <TableHead>Class</TableHead>
+                <TableHead className="hidden md:table-cell">Code</TableHead>
+                <TableHead>Relationship</TableHead>
+                <TableHead className="text-right pr-6">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {children.map((child) => (
+                <TableRow
+                  key={child.id}
+                  className="border-t border-[#D7E3FC]"
+                >
+                  <TableCell className="pl-6 font-medium text-slate-900">
+                    {child.fullName}
+                  </TableCell>
+                  <TableCell>
+                    {[child.className, child.section]
+                      .filter(Boolean)
+                      .join(" - ") || "-"}
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell">
+                    {child.studentCode ?? "-"}
+                  </TableCell>
+                  <TableCell>
+                    {formatRelationship(child.relationship)}
+                  </TableCell>
+                  <TableCell className="text-right pr-6">
+                    <Button
+                      variant="ghost"
+                      disabled={unlinkingId === child.id || unlink.isPending}
+                      onClick={() =>
+                        void handleUnlink(child.id, child.fullName)
+                      }
+                    >
+                      {unlinkingId === child.id ? "Unlinking…" : "Unlink"}
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <LinkChildrenDialog
+        open={linkOpen}
+        parentId={parent.id}
+        alreadyLinkedIds={linkedIds}
+        onClose={() => setLinkOpen(false)}
+        onLinked={() => onChanged?.()}
+      />
+    </div>
+  );
+}

--- a/src/modules/parents/components/ParentsTable.tsx
+++ b/src/modules/parents/components/ParentsTable.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import type { Parent } from "@/modules/parents/types";
+import { Skeleton } from "@/components/ui/Skeleton";
+
+type Props = {
+  parents: Parent[];
+  loading: boolean;
+  error: string | null;
+  total?: number;
+  page?: number;
+  pageSize?: number;
+  onRetry: () => void;
+  onPageChange: (page: number) => void;
+};
+
+function getPageNumbers(page: number, totalPages: number) {
+  const pages: (number | "ellipsis")[] = [];
+  const maxVisiblePages = 5;
+
+  if (totalPages <= maxVisiblePages) {
+    for (let i = 1; i <= totalPages; i++) pages.push(i);
+    return pages;
+  }
+
+  pages.push(1);
+  if (page > 3) pages.push("ellipsis");
+
+  const start = Math.max(2, page - 1);
+  const end = Math.min(totalPages - 1, page + 1);
+  for (let i = start; i <= end; i++) {
+    if (i > 1 && i < totalPages) pages.push(i);
+  }
+
+  if (page < totalPages - 2) pages.push("ellipsis");
+  pages.push(totalPages);
+  return pages;
+}
+
+function ParentsTableSkeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div className="rounded-lg bg-white border border-[#D7E3FC] p-4 space-y-3">
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-12 w-full" />
+      ))}
+    </div>
+  );
+}
+
+export default function ParentsTable({
+  parents,
+  loading,
+  error,
+  total = 0,
+  page = 1,
+  pageSize = 10,
+  onRetry,
+  onPageChange,
+}: Props) {
+  const router = useRouter();
+  const totalCount = total || parents.length;
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const showPagination = totalCount > pageSize && totalPages > 1;
+
+  if (loading) {
+    return <ParentsTableSkeleton rows={pageSize} />;
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <div className="flex flex-col items-start gap-4">
+          <div className="text-sm text-slate-700">Error: {error}</div>
+          <Button onClick={onRetry}>Retry</Button>
+        </div>
+      </Card>
+    );
+  }
+
+  if (!parents || parents.length === 0) {
+    return (
+      <Card>
+        <div className="text-center">
+          <h3 className="text-lg font-medium text-slate-900">No parents found</h3>
+          <p className="mt-1 text-sm text-slate-600">
+            Try adjusting filters or add a new parent.
+          </p>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="rounded-lg bg-white border border-[#D7E3FC]">
+      <div className="overflow-x-auto">
+        <Table className="w-full table-auto">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="pl-6">Parent Name</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead className="hidden lg:table-cell">Mobile</TableHead>
+              <TableHead className="hidden lg:table-cell">Children</TableHead>
+              <TableHead className="hidden md:table-cell">Status</TableHead>
+              <TableHead className="text-right pr-6">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {parents.map((p) => (
+              <TableRow
+                key={p.id}
+                className="border-t border-[#D7E3FC] text-[#021034] text-[14px] font-[500] hover:bg-slate-50"
+              >
+                <TableCell className="pl-6">
+                  <div className="font-medium text-slate-900">
+                    {p.fullName || `${p.firstName} ${p.lastName}`}
+                  </div>
+                </TableCell>
+                <TableCell className="text-[#737373]">{p.email}</TableCell>
+                <TableCell className="hidden lg:table-cell">
+                  {p.mobile ?? "-"}
+                </TableCell>
+                <TableCell className="hidden lg:table-cell">
+                  {p.childrenCount ?? 0}
+                </TableCell>
+                <TableCell className="hidden md:table-cell">
+                  <span className="inline-flex rounded-md bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700">
+                    {p.status ?? "-"}
+                  </span>
+                </TableCell>
+                <TableCell className="text-right pr-6">
+                  <Button
+                    variant="ghost"
+                    className="cursor-pointer"
+                    onClick={() => router.push(`/admin/parents/${p.id}`)}
+                  >
+                    View
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {showPagination && (
+        <>
+          <div className="border-t border-[#D7E3FC] mt-4" />
+          <div className="mt-4 flex flex-col sm:flex-row items-center justify-between gap-4 px-6 pb-4">
+            <div className="text-sm text-slate-600">
+              Showing {parents.length} of {totalCount}
+            </div>
+            <Pagination className="mx-0 w-auto">
+              <PaginationContent>
+                <PaginationItem>
+                  <PaginationPrevious
+                    onClick={() => onPageChange(Math.max(1, page - 1))}
+                    disabled={page <= 1}
+                    className="cursor-pointer"
+                  />
+                </PaginationItem>
+                {getPageNumbers(page, totalPages).map((pageNumber, idx) => (
+                  <PaginationItem key={idx}>
+                    {pageNumber === "ellipsis" ? (
+                      <PaginationEllipsis />
+                    ) : (
+                      <PaginationLink
+                        isActive={pageNumber === page}
+                        onClick={() => onPageChange(pageNumber)}
+                        className="cursor-pointer"
+                      >
+                        {pageNumber}
+                      </PaginationLink>
+                    )}
+                  </PaginationItem>
+                ))}
+                <PaginationItem>
+                  <PaginationNext
+                    onClick={() =>
+                      onPageChange(Math.min(totalPages, page + 1))
+                    }
+                    disabled={page >= totalPages}
+                    className="cursor-pointer"
+                  />
+                </PaginationItem>
+              </PaginationContent>
+            </Pagination>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/modules/parents/constants/query-keys.ts
+++ b/src/modules/parents/constants/query-keys.ts
@@ -1,0 +1,14 @@
+export const PARENTS_PAGE_SIZE = 10;
+
+export const parentQueryKeys = {
+  all: ["parents"] as const,
+  lists: () => [...parentQueryKeys.all, "list"] as const,
+  list: (query: {
+    search?: string;
+    status?: string;
+    page?: number;
+    pageSize?: number;
+  }) => [...parentQueryKeys.lists(), query] as const,
+  details: () => [...parentQueryKeys.all, "detail"] as const,
+  detail: (id: string) => [...parentQueryKeys.details(), id] as const,
+};

--- a/src/modules/parents/hooks/useParentPortal.ts
+++ b/src/modules/parents/hooks/useParentPortal.ts
@@ -1,0 +1,7 @@
+"use client";
+
+/** @deprecated Prefer `@/modules/parent-portal` */
+export {
+  useParentMeQuery,
+  useParentChildrenQuery,
+} from "@/modules/parent-portal/hooks/useParentPortal";

--- a/src/modules/parents/hooks/useParents.ts
+++ b/src/modules/parents/hooks/useParents.ts
@@ -1,0 +1,105 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createParent,
+  fetchParents,
+  getParentById,
+  linkChildren,
+  unlinkChild,
+  updateParent,
+} from "@/modules/parents/api/adminParents";
+import {
+  PARENTS_PAGE_SIZE,
+  parentQueryKeys,
+} from "@/modules/parents/constants/query-keys";
+import type {
+  CreateParentPayload,
+  LinkChildrenPayload,
+  ParentsQuery,
+  UpdateParentPayload,
+} from "@/modules/parents/types";
+
+export function useParentsQuery(query: ParentsQuery = {}) {
+  const page = query.page ?? 1;
+  const pageSize = query.pageSize ?? PARENTS_PAGE_SIZE;
+
+  return useQuery({
+    queryKey: parentQueryKeys.list({
+      search: query.search,
+      status: query.status,
+      page,
+      pageSize,
+    }),
+    queryFn: () =>
+      fetchParents({
+        ...query,
+        page,
+        pageSize,
+      }),
+  });
+}
+
+export function useParentQuery(id: string | undefined) {
+  return useQuery({
+    queryKey: parentQueryKeys.detail(id ?? ""),
+    queryFn: () => getParentById(id!),
+    enabled: Boolean(id),
+  });
+}
+
+export function useParentMutations() {
+  const qc = useQueryClient();
+  const invalidate = () =>
+    qc.invalidateQueries({ queryKey: parentQueryKeys.all });
+
+  const create = useMutation({
+    mutationFn: (payload: CreateParentPayload) => createParent(payload),
+    onSuccess: invalidate,
+  });
+
+  const update = useMutation({
+    mutationFn: ({
+      id,
+      payload,
+    }: {
+      id: string;
+      payload: UpdateParentPayload;
+    }) => updateParent(id, payload),
+    onSuccess: invalidate,
+  });
+
+  const link = useMutation({
+    mutationFn: ({
+      parentId,
+      payload,
+    }: {
+      parentId: string;
+      payload: LinkChildrenPayload;
+    }) => linkChildren(parentId, payload),
+    onSuccess: (_data, vars) => {
+      void qc.invalidateQueries({ queryKey: parentQueryKeys.all });
+      void qc.invalidateQueries({
+        queryKey: parentQueryKeys.detail(vars.parentId),
+      });
+    },
+  });
+
+  const unlink = useMutation({
+    mutationFn: ({
+      parentId,
+      studentId,
+    }: {
+      parentId: string;
+      studentId: string;
+    }) => unlinkChild(parentId, studentId),
+    onSuccess: (_data, vars) => {
+      void qc.invalidateQueries({ queryKey: parentQueryKeys.all });
+      void qc.invalidateQueries({
+        queryKey: parentQueryKeys.detail(vars.parentId),
+      });
+    },
+  });
+
+  return { create, update, link, unlink, invalidate };
+}

--- a/src/modules/parents/index.ts
+++ b/src/modules/parents/index.ts
@@ -1,0 +1,29 @@
+export * from "./api/adminParents";
+export * from "./api/portal";
+export * from "./types";
+export {
+  createParentSchema,
+  updateParentSchema,
+  linkChildrenSchema,
+  PARENT_RELATIONSHIP_OPTIONS,
+  type CreateParentValues,
+  type UpdateParentValues,
+  type LinkChildrenValues,
+} from "./schemas/parent.schemas";
+export {
+  PARENTS_PAGE_SIZE,
+  parentQueryKeys,
+} from "./constants/query-keys";
+export {
+  useParentsQuery,
+  useParentQuery,
+  useParentMutations,
+} from "./hooks/useParents";
+export {
+  useParentMeQuery,
+  useParentChildrenQuery,
+} from "./hooks/useParentPortal";
+export { default as ParentsTable } from "./components/ParentsTable";
+export { default as CreateParentDialog } from "./components/CreateParentDialog";
+export { default as LinkChildrenDialog } from "./components/LinkChildrenDialog";
+export { default as ParentDetailView } from "./components/ParentDetailView";

--- a/src/modules/parents/schemas/parent.schemas.ts
+++ b/src/modules/parents/schemas/parent.schemas.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+
+const phoneDigitsOnly = (val: string) => val.replace(/[^0-9]/g, "");
+
+export const PARENT_RELATIONSHIP_OPTIONS = [
+  { id: "FATHER", name: "Father" },
+  { id: "MOTHER", name: "Mother" },
+  { id: "GUARDIAN", name: "Guardian" },
+  { id: "OTHER", name: "Other" },
+] as const;
+
+export const createParentSchema = z.object({
+  firstName: z.string().min(1, "First name is required"),
+  lastName: z.string().min(1, "Last name is required"),
+  email: z.string().email("Must be a valid email"),
+  mobile: z
+    .string()
+    .min(1, "Phone is required")
+    .transform((s) => s.trim())
+    .refine((s) => /^[+0-9 ]+$/.test(s), {
+      message: "Phone can contain only +, digits and spaces",
+    })
+    .refine((s) => {
+      const digits = phoneDigitsOnly(s);
+      return digits.length >= 10 && digits.length <= 15;
+    }, "Phone should contain 10 to 15 digits"),
+  address: z.string().optional(),
+  gender: z.enum(["MALE", "FEMALE", "OTHER"]).optional(),
+  dateOfBirth: z
+    .string()
+    .optional()
+    .refine(
+      (s) => !s || !Number.isNaN(new Date(s).getTime()),
+      "Invalid date",
+    ),
+});
+
+export type CreateParentValues = z.infer<typeof createParentSchema>;
+
+export const updateParentSchema = createParentSchema.partial().extend({
+  status: z.string().optional(),
+});
+
+export type UpdateParentValues = z.infer<typeof updateParentSchema>;
+
+export const linkChildItemSchema = z.object({
+  studentUserId: z.string().uuid("Select a valid student"),
+  relationship: z
+    .enum(["FATHER", "MOTHER", "GUARDIAN", "OTHER"])
+    .default("GUARDIAN"),
+});
+
+export const linkChildrenSchema = z.object({
+  children: z
+    .array(linkChildItemSchema)
+    .min(1, "Select at least one child"),
+});
+
+export type LinkChildrenValues = z.infer<typeof linkChildrenSchema>;

--- a/src/modules/parents/types/index.ts
+++ b/src/modules/parents/types/index.ts
@@ -1,0 +1,76 @@
+export type ParentRelationship =
+  | "FATHER"
+  | "MOTHER"
+  | "GUARDIAN"
+  | "OTHER";
+
+export type ParentStatus = "ACTIVE" | "INACTIVE" | "SUSPENDED" | "PENDING";
+
+export type ParentChild = {
+  id: string;
+  fullName: string;
+  studentCode?: string | null;
+  classId?: string | null;
+  className?: string | null;
+  section?: string | null;
+  relationship: ParentRelationship;
+};
+
+export type Parent = {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  fullName: string;
+  mobile?: string | null;
+  address?: string | null;
+  gender?: string | null;
+  status: string;
+  childrenCount: number;
+  children?: ParentChild[];
+  createdAt?: string;
+};
+
+export type ParentsQuery = {
+  search?: string;
+  status?: string;
+  page?: number;
+  pageSize?: number;
+};
+
+export type ParentsResponse = {
+  parents: Parent[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export type CreateParentPayload = {
+  email: string;
+  firstName: string;
+  lastName: string;
+  mobile: string;
+  address?: string;
+  gender?: "MALE" | "FEMALE" | "OTHER";
+  dateOfBirth?: string;
+};
+
+export type CreateParentResponse = {
+  email: string;
+  temporaryPassword: string;
+  parentId: string;
+  message: string;
+};
+
+export type UpdateParentPayload = Partial<CreateParentPayload> & {
+  status?: string;
+};
+
+export type LinkChildItem = {
+  studentUserId: string;
+  relationship?: ParentRelationship;
+};
+
+export type LinkChildrenPayload = {
+  children: LinkChildItem[];
+};

--- a/src/modules/students/api/portal.ts
+++ b/src/modules/students/api/portal.ts
@@ -10,6 +10,118 @@ export type StudentAttendancePage = {
   total: number;
 };
 
+export type StudentClassRef = {
+  id: string;
+  name: string;
+  section?: string | null;
+};
+
+export type StudentTimetableItem = {
+  dayOfWeek?: number | null;
+  subject: string | null;
+  startTime: string | null;
+  endTime: string | null;
+  subjectTeacher?: string | null;
+  teacher?: string | null;
+  teacherName?: string | null;
+  room: string | null;
+};
+
+export type StudentAnnouncementItem = {
+  id: string;
+  title: string;
+  body: string;
+  publishedAt: string;
+  authorName?: string | null;
+  pinned?: boolean;
+};
+
+export type StudentAnnouncementsPage = {
+  items: StudentAnnouncementItem[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
+export type StudentPortalDocument = {
+  id: string;
+  documentType: string;
+  url: string;
+  fileName?: string | null;
+  originalName?: string | null;
+  mimeType?: string | null;
+  size?: number | null;
+  createdAt?: string | null;
+};
+
+export type StudentFeesSummary = {
+  totalOutstanding: number;
+  totalPaid: number;
+  overdueCount: number;
+  pendingCount: number;
+  totalAssignments: number;
+};
+
+export type StudentExamScheduleGroup = {
+  exam: {
+    id: string;
+    name: string;
+    academicYear?: string;
+    examType?: string;
+    status?: string;
+    className?: string | null;
+    classSection?: string | null;
+    startDate?: string | null;
+    endDate?: string | null;
+  };
+  schedules: Array<{
+    id: string;
+    subjectName?: string | null;
+    subjectCode?: string | null;
+    examDate: string;
+    startTime?: string | null;
+    endTime?: string | null;
+    maxMarks?: number;
+    passMarks?: number;
+    venue?: string | null;
+  }>;
+};
+
+export type StudentDashboard = {
+  totalDays: number;
+  presentDays: number;
+  absentDays: number;
+  leaveDays: number;
+  attendancePercentage: number;
+  profile?: {
+    id: string;
+    fullName: string;
+    studentCode?: string | null;
+    class?: StudentClassRef | null;
+  };
+  currentClass?: StudentClassRef | null;
+  timetable?: StudentTimetableItem[];
+  recentAnnouncements?: StudentAnnouncementItem[];
+  documents?: {
+    count: number;
+    items: StudentPortalDocument[];
+  };
+};
+
+function normalizeTimetable(data: unknown): StudentTimetableItem[] {
+  if (Array.isArray(data)) {
+    return data as StudentTimetableItem[];
+  }
+  if (
+    data &&
+    typeof data === "object" &&
+    Array.isArray((data as { schedules?: unknown }).schedules)
+  ) {
+    return (data as { schedules: StudentTimetableItem[] }).schedules;
+  }
+  return [];
+}
+
 export async function getStudentMe(): Promise<StudentMe> {
   const res = await API.get(STUDENT_API.ME);
   return (res.data ?? {}) as StudentMe;
@@ -51,8 +163,79 @@ export async function changePassword(payload: {
   oldPassword: string;
   newPassword: string;
 }): Promise<unknown> {
-  const res = await API.post(STUDENT_API.CHANGE_PASSWORD, payload);
+  const res = await API.patch(STUDENT_API.CHANGE_PASSWORD, {
+    currentPassword: payload.oldPassword,
+    newPassword: payload.newPassword,
+  });
   return res.data;
+}
+
+export async function getStudentDashboard(): Promise<StudentDashboard> {
+  const res = await API.get(STUDENT_API.DASHBOARD);
+  const data = (res.data ?? {}) as StudentDashboard;
+  return {
+    ...data,
+    timetable: normalizeTimetable(data.timetable),
+  };
+}
+
+export async function getTimetable(): Promise<StudentTimetableItem[]> {
+  const res = await API.get(STUDENT_API.TIMETABLE);
+  return normalizeTimetable(res.data);
+}
+
+export async function getStudentDocuments(): Promise<StudentPortalDocument[]> {
+  const res = await API.get(STUDENT_API.DOCUMENTS);
+  const data = res.data;
+  if (Array.isArray(data)) return data as StudentPortalDocument[];
+  if (data && Array.isArray(data.items)) {
+    return data.items as StudentPortalDocument[];
+  }
+  if (data && Array.isArray(data.data)) {
+    return data.data as StudentPortalDocument[];
+  }
+  return [];
+}
+
+export async function getClassAnnouncements(
+  page = 1,
+  limit = 20,
+): Promise<StudentAnnouncementsPage> {
+  const res = await API.get(STUDENT_API.ANNOUNCEMENTS, {
+    params: { page, limit },
+  });
+  const data = res.data ?? {};
+  const items = Array.isArray(data.items)
+    ? data.items
+    : Array.isArray(data.data)
+      ? data.data
+      : Array.isArray(data)
+        ? data
+        : [];
+  return {
+    items: items as StudentAnnouncementItem[],
+    total: typeof data.total === "number" ? data.total : items.length,
+    page: typeof data.page === "number" ? data.page : page,
+    limit: typeof data.limit === "number" ? data.limit : limit,
+  };
+}
+
+export async function getFeesSummary(): Promise<StudentFeesSummary> {
+  const res = await API.get(STUDENT_API.FEES_SUMMARY);
+  return (res.data ?? {
+    totalOutstanding: 0,
+    totalPaid: 0,
+    overdueCount: 0,
+    pendingCount: 0,
+    totalAssignments: 0,
+  }) as StudentFeesSummary;
+}
+
+export async function getExamsSchedule(): Promise<StudentExamScheduleGroup[]> {
+  const res = await API.get(STUDENT_API.EXAMS_SCHEDULE);
+  const data = res.data;
+  if (Array.isArray(data)) return data as StudentExamScheduleGroup[];
+  return [];
 }
 
 const studentApi = {
@@ -61,6 +244,12 @@ const studentApi = {
   getAttendanceSummary,
   getAttendanceHistory,
   changePassword,
+  getStudentDashboard,
+  getTimetable,
+  getStudentDocuments,
+  getClassAnnouncements,
+  getFeesSummary,
+  getExamsSchedule,
 };
 
 export default studentApi;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -15,6 +15,7 @@ const ROLE_DASHBOARDS: Record<string, string> = {
   admin: "/admin/dashboard",
   teacher: "/teacher/dashboard",
   student: "/student/dashboard",
+  parent: "/parent/dashboard",
 };
 
 /** Role → allowed path prefix (not just dashboard). */
@@ -22,6 +23,7 @@ const ROLE_PREFIXES: Record<string, string> = {
   admin: "/admin",
   teacher: "/teacher",
   student: "/student",
+  parent: "/parent",
 };
 
 function isPublicPath(cleanPath: string): boolean {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,1 +1,1 @@
-export type Role = "admin" | "teacher" | "student";
+export type Role = "admin" | "teacher" | "student" | "parent";


### PR DESCRIPTION
## Summary
- Merge fee and examination UI; add `parent` role across login, session, proxy, and nav.
- Admin Parents management (create, list, detail, link/unlink children with temp password).
- Complete Student portal pages (dashboard, timetable, announcements, documents, fees summary, exams schedule) and a full child-scoped read-only Parent portal with switcher/subnav.

## Test plan
- [ ] Login tabs include Parent; parent session redirects to `/parent/dashboard`
- [ ] Admin → Parents: create parent, link children, unlink child
- [ ] Parent portal: open child dashboard and each section (profile, attendance, timetable, homework, fees, exams, announcements, documents) — all read-only
- [ ] Student portal: navigate all new nav items; dashboard sections load with empty/error states
- [ ] Cross-role routes still redirect to `/unauthorized`


Made with [Cursor](https://cursor.com)