### PR TITLE
Fix admin class filter params for teachers (#77)

### DIFF
--- a/src/app/admin/students/page.tsx
+++ b/src/app/admin/students/page.tsx
@@ -48,7 +48,7 @@ export default function AdminStudentsPage() {
     let mounted = true;
     (async () => {
       try {
-        const resp = await fetchClasses({ pageSize: 1000 });
+        const resp = await fetchClasses({ pageSize: 100 });
         if (!mounted) return;
         setClasses(resp.classes ?? []);
       } catch {

--- a/src/app/admin/teachers/page.tsx
+++ b/src/app/admin/teachers/page.tsx
@@ -46,7 +46,10 @@ export default function AdminTeachersPage() {
   );
 
   const classOptions = useMemo(() => {
-    return classes.map((c) => ({ id: c.id, name: c.name }));
+    return classes.map((c) => ({
+      id: c.id,
+      name: c.section ? `${c.name} - ${c.section}` : c.name,
+    }));
   }, [classes]);
 
   const load = useCallback(
@@ -104,8 +107,8 @@ export default function AdminTeachersPage() {
     (async () => {
       try {
         const [clsResp, subjResp] = await Promise.all([
-          fetchClasses({ pageSize: 1000 }),
-          fetchSubjects({ pageSize: 1000 }),
+          fetchClasses({ pageSize: 100 }),
+          fetchSubjects({ pageSize: 100 }),
         ]);
         if (!mounted) return;
         setClasses(clsResp.classes ?? []);

--- a/src/modules/subjects/api/subjects.ts
+++ b/src/modules/subjects/api/subjects.ts
@@ -19,8 +19,10 @@ export async function fetchSubjects(
   if (query.search) params.search = query.search;
   if (query.page) params.page = query.page;
   if (query.pageSize) {
-    params.pageSize = query.pageSize;
-    params.limit = query.pageSize;
+    // Backend PaginationSubjectDto enforces @Max(100) on `limit`
+    const limit = Math.min(query.pageSize, 100);
+    params.pageSize = limit;
+    params.limit = limit;
   }
   const res = await API.get<{
     subjects?: Subject[];

--- a/src/modules/teachers/api/adminTeachers.ts
+++ b/src/modules/teachers/api/adminTeachers.ts
@@ -28,12 +28,18 @@ export async function fetchTeachers(
   ].filter(Boolean);
   // Backend accepts repeated or comma-separated subjectIds (specialty filter).
   if (subjectIds.length) params.subjectIds = subjectIds.join(",");
-  if (query.classId) params.classId = query.classId;
+
+  const classIds = [
+    ...(query.classIds ?? []),
+    ...(query.classId ? [query.classId] : []),
+  ].filter(Boolean);
+  // Backend expects `classIds` (whitelist strips unknown `classId`).
+  if (classIds.length) params.classIds = classIds.join(",");
+
   if (query.page) params.page = query.page;
   if (query.pageSize) {
-    params.pageSize = query.pageSize;
-    // some APIs expect `limit` instead of `pageSize`
-    params.limit = query.pageSize;
+    // Backend PaginationTeacherDto uses `limit` (@Max(100)); pageSize is ignored.
+    params.limit = Math.min(query.pageSize, 100);
   }
   const res = await API.get<TeachersResponse>(ADMIN_API.TEACHERS, {
     params,

--- a/src/modules/teachers/types/admin.ts
+++ b/src/modules/teachers/types/admin.ts
@@ -41,7 +41,10 @@ export type TeachersQuery = {
   subjectId?: string;
   /** Filter by subject specialty IDs (match any). */
   subjectIds?: string[];
+  /** Filter by class (single id; sent as classIds to API). */
   classId?: string;
+  /** Filter by class IDs (subject teacher or class teacher; match any). */
+  classIds?: string[];
   page?: number;
   pageSize?: number;
 };


### PR DESCRIPTION
## Summary
- Send `classIds` (and `limit`) from the teachers list API client so the backend class filter is applied instead of being stripped as unknown `classId`/`pageSize`.
- Cap subject/class filter fetches at `pageSize`/`limit` 100 to satisfy backend `@Max(100)` validation.
- Show class section in the teachers class filter dropdown labels (e.g. `Class 10 - A`).

Fixes https://github.com/engr-shubhampatidar/school-connect-mgmt-frontend/issues/77

## Test plan
- [ ] Open `/admin/teachers` and confirm Class/Subject filters load without `limit must not be greater than 100`
- [ ] Select a class with section in the filter and confirm the request uses `classIds=...&limit=10`
- [ ] Confirm only teachers linked to that class are returned
- [ ] Confirm dropdown labels include section and no duplicate-key console noise from missing section labels
- [ ] Smoke-check `/admin/students` class filter still loads options


Made with [Cursor](https://cursor.com)